### PR TITLE
debian: Package pam_malcontent.so PAM module

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+malcontent (0.4.0-1) unstable; urgency=medium
+
+  * Package new pam_malcontent.so PAM module for time limited login sessions
+    - Will be released upstream in 0.5.0
+    - Creates new malcontent-pam subpackage
+    - Adds a dependency on libpam0g
+
+ -- Philip Withnall <withnall@endless.com>  Fri, 17 Jan 2020 11:58:00 +0000
+
 malcontent (0.4.0-0) unstable; urgency=medium
 
   * Bump to upstream 0.4.0

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Build-Depends:
  libdbus-1-dev,
  libgirepository1.0-dev (>= 1.30.0),
  libglib2.0-dev (>= 2.54.2),
+ libpam0g-dev,
  meson,
  policykit-1,
  python3-gi,
@@ -27,6 +28,18 @@ Conflicts: eos-parental-controls-data
 Replaces: eos-parental-controls-data
 Description: Parental Controls - architecture independent files
  This package contains the architecture-independent data files.
+
+Package: malcontent-pam
+Section: misc
+Architecture: any
+Multi-arch: same
+Depends:
+ malcontent-data (= ${source:Version}),
+ ${misc:Depends},
+ ${shlibs:Depends},
+Description: Parental Controls PAM Module
+ This package contains a PAM module which prevents logins for users who have
+ exceeded their allowed computer time.
 
 Package: malcontent-tools
 Section: misc

--- a/debian/malcontent-data.install
+++ b/debian/malcontent-data.install
@@ -1,4 +1,6 @@
 usr/share/accountsservice/interfaces/com.endlessm.ParentalControls.AppFilter.xml
+usr/share/accountsservice/interfaces/com.endlessm.ParentalControls.SessionLimits.xml
 usr/share/dbus-1/interfaces/com.endlessm.ParentalControls.AppFilter.xml
+usr/share/dbus-1/interfaces/com.endlessm.ParentalControls.SessionLimits.xml
 usr/share/polkit-1/actions/com.endlessm.ParentalControls.policy
 usr/share/polkit-1/rules.d/com.endlessm.ParentalControls.rules

--- a/debian/malcontent-pam.install
+++ b/debian/malcontent-pam.install
@@ -1,0 +1,1 @@
+usr/lib/security/pam_malcontent.so


### PR DESCRIPTION
This is a packaging update to add the necessary dependencies and new subpackage for the PAM module.

The corresponding code changes are in https://github.com/endlessm/malcontent/pull/8.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28747