### PR TITLE
Fix pamlibdir

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -29,7 +29,7 @@ accountsserviceinterfacesdir = join_paths(datadir, 'accountsservice', 'interface
 # FIXME: pam.pc doesn’t exist
 pamlibdir = get_option('pamlibdir')
 if pamlibdir == ''
-  pamlibdir = join_paths(prefix, libdir.split('/')[-1], 'security')
+  pamlibdir = join_paths(libdir, 'security')
 endif
 
 dbus = dependency('dbus-1')


### PR DESCRIPTION
This merges in https://gitlab.freedesktop.org/pwithnall/malcontent/merge_requests/21 (only) from upstream.

---

The corresponding Debian changes are in #11. This should fix this [OBS failure](https://obs-master.endlessm-sf.com/package/live_build_log/eos:master:endless/malcontent/endless/x86_64).