### PR TITLE
debian: Fix installation path of pam_malcontent.so

### DIFF
--- a/debian/malcontent-pam.install
+++ b/debian/malcontent-pam.install
@@ -1,1 +1,1 @@
-usr/lib/security/pam_malcontent.so
+usr/lib/*/security/pam_malcontent.so


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

---

The corresponding code changes are in #10. This should fix this [OBS failure](https://obs-master.endlessm-sf.com/package/live_build_log/eos:master:endless/malcontent/endless/x86_64).