### PR TITLE
debian: Add .so files to *-dev packages

### DIFF
--- a/debian/libmalcontent-0-dev.install
+++ b/debian/libmalcontent-0-dev.install
@@ -1,3 +1,4 @@
 usr/include/malcontent-0
+usr/lib/*/libmalcontent-0.so
 usr/lib/*/pkgconfig/malcontent-0.pc
 usr/share/gir-1.0/Malcontent-0.gir

--- a/debian/libmalcontent-ui-0-dev.install
+++ b/debian/libmalcontent-ui-0-dev.install
@@ -1,3 +1,4 @@
 usr/include/malcontent-ui-0
+usr/lib/*/libmalcontent-ui-0.so
 usr/lib/*/pkgconfig/malcontent-ui-0.pc
 usr/share/gir-1.0/MalcontentUi-0.gir


### PR DESCRIPTION
Commit a682f9584 actually did break things, since it was previously
installing the .so file into the library package; it should be installed
into the -dev package.

Signed-off-by: Philip Withnall <withnall@endlessm.com>