### PR TITLE
user-controls: Make OARS drop down open to the right

### DIFF
--- a/libmalcontent-ui/user-controls.ui
+++ b/libmalcontent-ui/user-controls.ui
@@ -491,6 +491,7 @@
                         <property name="can_focus">True</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
+                        <property name="direction">right</property>
                         <property name="popover">oars_popover</property>
                         <child>
                           <object class="GtkBox">


### PR DESCRIPTION
On laptops which have a 1366 by 768 display, in gnome-initial-setup the
OARS dropdown is cut off by the edge of the screen. Only the first
couple entries are visible. So make it open to the right instead, where
more room is available.