### PR TITLE
debian: Add dependency on eos-metrics-0-dev for downstream metrics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+malcontent (0.6.0-1endless1) master; urgency=medium
+
+  * Add dependency on eos-metrics-0-dev for downstream metrics (T28742)
+
+ -- Philip Withnall <withnall@endlessm.com>  Mon, 23 Mar 2020 15:01:00 +0000
+
 malcontent (0.6.0-1) master; urgency=medium
 
   * Upstream 0.6.0 release

--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Philip Withnall <withnall@endlessm.com>
 Standards-Version: 4.3.0
 Build-Depends:
  debhelper-compat (= 12),
+ eos-metrics-0-dev (>= 0.5.0),
  gir1.2-glib-2.0,
  gobject-introspection (>= 1.30.0),
  gtk-doc-tools,


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28742

---

Code changes in #17.