### PR TITLE
debian: Package the help files backported from upstream

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+malcontent (0.7.0-2) master; urgency=medium
+
+  * Package the help files backported from upstream (T28746)
+
+ -- Philip Withnall <withnall@endlessm.com>  Fri, 03 Apr 2020 15:41:00 +0100
+
 malcontent (0.7.0-1) master; urgency=medium
 
   * Upstream 0.7.0 release

--- a/debian/malcontent-control.install
+++ b/debian/malcontent-control.install
@@ -1,4 +1,5 @@
 usr/bin/malcontent-control
+usr/share/help/*/malcontent
 usr/share/icons/hicolor/symbolic/apps/org.freedesktop.MalcontentControl-symbolic.svg
 usr/share/icons/hicolor/scalable/apps/org.freedesktop.MalcontentControl.svg
 usr/share/metainfo/org.freedesktop.MalcontentControl.appdata.xml


### PR DESCRIPTION
Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T28746

---

Code changes: #21