### PR TITLE
malcontent-control: Add a header bar and primary menu

### DIFF
--- a/malcontent-control/main.ui
+++ b/malcontent-control/main.ui
@@ -5,6 +5,30 @@
   <object class="GtkApplicationWindow" id="main_window">
     <property name="default-width">500</property>
     <property name="default-height">600</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="header">
+        <property name="show-close-button">True</property>
+        <!-- Translators: This is the title of the main window -->
+        <property name="title" translatable="yes">Parental Controls</property>
+        <property name="visible">True</property>
+        <child>
+          <object class="GtkMenuButton" id="primary_menu">
+            <property name="visible">True</property>
+            <property name="direction">none</property>
+            <property name="can-focus">True</property>
+            <property name="use-popover">True</property>
+            <property name="menu-model">primary-menu</property>
+            <accelerator key="F10" signal="activate"/>
+            <style>
+              <class name="image-button"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+      </object>
+    </child>
     <child>
       <object class="GtkStack" id="main_stack">
         <property name="visible">True</property>
@@ -232,4 +256,17 @@
       </object>
     </child>
   </object>
+
+  <menu id="primary-menu">
+    <section>
+      <item>
+        <attribute name="action">app.help</attribute>
+        <attribute name="label" translatable="yes">_Help</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.about</attribute>
+        <attribute name="label" translatable="yes">_About Parental Controls</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>


### PR DESCRIPTION
This makes it easier to access the help and about dialogue, and brings
the application in line with the [GNOME
HIG](https://developer.gnome.org/hig/stable/header-bars.html.en).

Signed-off-by: Philip Withnall <withnall@endlessm.com>