### PR TITLE
T29711 Backport fixes for crash in g-i-s

### DIFF
--- a/libmalcontent-ui/user-controls.c
+++ b/libmalcontent-ui/user-controls.c
@@ -728,6 +728,17 @@ mct_user_controls_constructed (GObject *object)
   /* Chain up. */
   G_OBJECT_CLASS (mct_user_controls_parent_class)->constructed (object);
 
+  /* FIXME: Ideally there wouldn’t be this sync call in a constructor, but there
+   * seems to be no way around it if #MctUserControls is to be used from a
+   * GtkBuilder template: templates are initialised from within the parent
+   * widget’s init() function (not its constructed() function), so none of its
+   * properties will have been set and it won’t reasonably have been able to
+   * make an async call to initialise the bus connection itself. Binding
+   * construct-only properties in GtkBuilder doesn’t work (and wouldn’t help if
+   * it did). */
+  if (self->dbus_connection == NULL)
+    self->dbus_connection = g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL, NULL);
+
   g_assert (self->dbus_connection != NULL);
   self->manager = mct_manager_new (self->dbus_connection);
 }

--- a/libmalcontent/manager.c
+++ b/libmalcontent/manager.c
@@ -98,7 +98,7 @@ mct_manager_set_property (GObject      *object,
   switch ((MctManagerProperty) property_id)
     {
     case PROP_CONNECTION:
-      /* Construct-only. May be %NULL. */
+      /* Construct-only. May not be %NULL. */
       g_assert (self->connection == NULL);
       self->connection = g_value_dup_object (value);
       g_assert (self->connection != NULL);
@@ -167,7 +167,7 @@ mct_manager_class_init (MctManagerClass *klass)
   object_class->set_property = mct_manager_set_property;
 
   /**
-   * MctManager:connection:
+   * MctManager:connection: (not nullable)
    *
    * A connection to the system bus, where accounts-service runs. It’s provided
    * mostly for testing purposes, or to allow an existing connection to be


### PR DESCRIPTION
Trivial backport from https://gitlab.freedesktop.org/pwithnall/malcontent/-/merge_requests/60.

https://phabricator.endlessm.com/T29711