### PR TITLE
T30747 debian: Rebase on upstream 0.9.0 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+malcontent (0.9.0-1) master; urgency=medium
+
+  * Upstream 0.9.0 release
+   - Add libflatpak-dev as a dependency of libmalcontent-ui-0-dev; even
+     though it’s not used in any of the headers, it’s listed in
+     `Requires.private`, which means it’s needed when calling `pkg-config
+     --cflags` (but not `pkg-config --libs`) against `malcontent-ui-0`. See
+     https://github.com/mesonbuild/meson/issues/3970#issuecomment-411406391
+     for an explanation of this.
+   - Add libappstream-glib-dev as a build-dependency
+   - d/rules: Add `-Dprivileged_group=sudo` for new upstream option
+
+ -- Philip Withnall <withnall@endlessm.com>  Tue, 08 Sep 2020 13:41:00 +0100
+
 malcontent (0.8.0-1) master; urgency=medium
 
   * Upstream 0.8.0 release (T29913)

--- a/debian/control
+++ b/debian/control
@@ -11,6 +11,7 @@ Build-Depends:
  gtk-doc-tools,
  itstool,
  libaccountsservice-dev (>= 0.6.39),
+ libappstream-glib-dev,
  libdbus-1-dev,
  libflatpak-dev,
  libgirepository1.0-dev (>= 1.30.0),
@@ -156,6 +157,7 @@ Architecture: any
 Multi-arch: same
 Depends:
  libaccountsservice-dev,
+ libflatpak-dev,
  libglib2.0-dev,
  libgtk-3-dev,
  libmalcontent-0-dev (= ${source:Version}),

--- a/debian/rules
+++ b/debian/rules
@@ -8,6 +8,7 @@ override_dh_auto_configure:
 	dh_auto_configure \
 		-- \
 		-Dinstalled_tests=true \
+		-Dprivileged_group=sudo \
 		$(NULL)
 
 override_dh_missing:


### PR DESCRIPTION
Associated code changes: #29 

This includes a potential fix for the issue of software which uses malcontent (such as g-i-s) not building on OBS due to a missing flatpak transitive dependency. CC @GeorgesStavracas.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T30747