### PR TITLE
debian/control: Add libappstream-glib-dev as a dependency

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+malcontent (0.9.0-2) master; urgency=medium
+
+  * Add libappstream-glib-dev as a dependency of libmalcontent-ui-0-dev
+    as its pkg-config file is needed in order to use malcontent-ui-0.pc
+    (T30173)
+
+ -- Philip Withnall <withnall@endlessm.com>  Wed, 09 Sep 2020 16:39:00 +0100
+
 malcontent (0.9.0-1) master; urgency=medium
 
   * Upstream 0.9.0 release

--- a/debian/control
+++ b/debian/control
@@ -157,6 +157,7 @@ Architecture: any
 Multi-arch: same
 Depends:
  libaccountsservice-dev,
+ libappstream-glib-dev,
  libflatpak-dev,
  libglib2.0-dev,
  libgtk-3-dev,


### PR DESCRIPTION
It’s needed for `malcontent-ui-0.pc` to be usable.

Signed-off-by: Philip Withnall <withnall@endlessm.com>

https://phabricator.endlessm.com/T30173