### PR TITLE
T30972 Fix restrict apps selector in gnome-initial-setup

### DIFF
--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -372,6 +372,7 @@ app_compare_id_length_cb (gconstpointer a,
 {
   GAppInfo *info_a = (GAppInfo *) a, *info_b = (GAppInfo *) b;
   const gchar *id_a, *id_b;
+  gsize id_a_len, id_b_len;
 
   id_a = g_app_info_get_id (info_a);
   id_b = g_app_info_get_id (info_b);
@@ -383,7 +384,12 @@ app_compare_id_length_cb (gconstpointer a,
   else if (id_b == NULL)
     return 1;
 
-  return strlen (id_a) - strlen (id_b);
+  id_a_len = strlen (id_a);
+  id_b_len = strlen (id_b);
+  if (id_a_len == id_b_len)
+    return strcmp (id_a, id_b);
+  else
+    return id_a_len - id_b_len;
 }
 
 static void

--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -389,7 +389,8 @@ app_compare_id_length_cb (gconstpointer a,
 static void
 reload_apps (MctRestrictApplicationsSelector *self)
 {
-  GList *iter, *apps;
+  g_autolist(GAppInfo) apps = NULL;
+  GList *iter;
   g_autoptr(GHashTable) seen_flatpak_ids = NULL;
   g_autoptr(GHashTable) seen_executables = NULL;
 
@@ -485,8 +486,6 @@ reload_apps (MctRestrictApplicationsSelector *self)
                                   compare_app_info_cb,
                                   self);
     }
-
-  g_list_free_full (apps, g_object_unref);
 }
 
 static void

--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -586,14 +586,9 @@ static void
 app_info_changed_cb (GAppInfoMonitor *monitor,
                      gpointer         user_data)
 {
-  /* FIXME: We should update the list of apps here, but we can’t call
-   * reload_apps() because that will dump and reload the entire list, losing
-   * any changes the user has already made to the set of switches. We need
-   * something more fine-grained.
   MctRestrictApplicationsSelector *self = MCT_RESTRICT_APPLICATIONS_SELECTOR (user_data);
 
   reload_apps (self);
-   */
 }
 
 /* Will return %NULL if @flatpak_id is not installed. */

--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -104,6 +104,9 @@ mct_restrict_applications_selector_constructed (GObject *obj)
 
   g_assert (self->app_filter != NULL);
 
+  /* Load the apps. */
+  reload_apps (self);
+
   G_OBJECT_CLASS (mct_restrict_applications_selector_parent_class)->constructed (obj);
 }
 


### PR DESCRIPTION
Trivial backport of the 5 commits from https://gitlab.freedesktop.org/pwithnall/malcontent/-/merge_requests/92.

https://phabricator.endlessm.com/T30972