### PR TITLE
malcontent-control: Drop ‘Restrict Application Installation for Others’

### DIFF
--- a/help/C/software-installation.page
+++ b/help/C/software-installation.page
@@ -8,10 +8,11 @@
 
   <title>Restricting Software Installation</title>
 
-  <p>You can prevent a user from installing additional software, either for the
-    entire system, or just for themselves. They will still be able to search for
-    new software to install, but will need an administrator to authorize the
-    installation when they try to install an application.</p>
+  <p>You can prevent a user from installing additional software on the system.
+    They will still be able to search for new software to install, but will need
+    an administrator to authorize the installation when they try to install an
+    application. This applies whether they are trying to install the application
+    system-wide (for all users) or just for themselves.</p>
 
   <p>Additionally, you can restrict which software a user can browse or search
     for in the <app>Software</app> catalog by age categories.</p>
@@ -27,18 +28,7 @@
       <item><p>Open the <app>Parental Controls</app> application.</p></item>
       <item><p>Select the user in the tabs at the top.</p></item>
       <item><p>Enable the <gui style="checkbox">Restrict Application Installation</gui> checkbox.</p></item>
-      <item><p>Or enable the <gui style="checkbox">Restrict Application Installation for Others</gui> checkbox.</p></item>
     </steps>
-
-    <p>The <gui style="checkbox">Restrict Application Installation for Others</gui>
-      checkbox allows the user to install additional software for themselves, but
-      prevents that software from being made available to other users. It could be
-      used, for example, if there were two child users, one of whom is mature
-      enough to be allowed to install additional software, but the other isn’t —
-      enabling <gui style="checkbox">Restrict Application Installation for Others</gui>
-      would prevent the more mature child from installing applications which are
-      inappropriate for the other child and making them available to the other
-      child.</p>
   </section>
 
   <section id="oars">

--- a/libmalcontent-ui/user-controls.c
+++ b/libmalcontent-ui/user-controls.c
@@ -77,10 +77,8 @@ struct _MctUserControls
   GtkGrid     parent_instance;
 
   GMenu      *age_menu;
-  GtkSwitch  *restrict_system_installation_switch;
-  GtkLabel   *restrict_system_installation_description;
-  GtkSwitch  *restrict_user_installation_switch;
-  GtkLabel   *restrict_user_installation_description;
+  GtkSwitch  *restrict_software_installation_switch;
+  GtkLabel   *restrict_software_installation_description;
   GtkSwitch  *restrict_web_browsers_switch;
   GtkLabel   *restrict_web_browsers_description;
   GtkButton  *oars_button;
@@ -443,8 +441,7 @@ update_oars_level (MctUserControls *self)
 static void
 update_allow_app_installation (MctUserControls *self)
 {
-  gboolean restrict_system_installation;
-  gboolean restrict_user_installation;
+  gboolean restrict_software_installation;
   gboolean non_admin_user = TRUE;
 
   if (self->user_account_type == ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR)
@@ -452,8 +449,7 @@ update_allow_app_installation (MctUserControls *self)
 
   /* Admins are always allowed to install apps for all users. This behaviour is governed
    * by flatpak polkit rules. Hence, these hide these defunct switches for admins. */
-  gtk_widget_set_visible (GTK_WIDGET (self->restrict_system_installation_switch), non_admin_user);
-  gtk_widget_set_visible (GTK_WIDGET (self->restrict_user_installation_switch), non_admin_user);
+  gtk_widget_set_visible (GTK_WIDGET (self->restrict_software_installation_switch), non_admin_user);
 
   /* If user is admin, we are done here, bail out. */
   if (!non_admin_user)
@@ -463,35 +459,22 @@ update_allow_app_installation (MctUserControls *self)
       return;
     }
 
-  restrict_system_installation = !mct_app_filter_is_system_installation_allowed (self->filter);
-  restrict_user_installation = !mct_app_filter_is_user_installation_allowed (self->filter);
-
   /* While the underlying permissions storage allows the system and user settings
    * to be stored completely independently, force the system setting to OFF if
    * the user setting is OFF in the UI. This keeps the policy in use for most
    * people simpler. */
-  if (restrict_user_installation)
-    restrict_system_installation = TRUE;
+  restrict_software_installation = !mct_app_filter_is_user_installation_allowed (self->filter);
 
-  g_signal_handlers_block_by_func (self->restrict_system_installation_switch,
+  g_signal_handlers_block_by_func (self->restrict_software_installation_switch,
                                    on_restrict_installation_switch_active_changed_cb,
                                    self);
 
-  g_signal_handlers_block_by_func (self->restrict_user_installation_switch,
-                                   on_restrict_installation_switch_active_changed_cb,
-                                   self);
+  gtk_switch_set_active (self->restrict_software_installation_switch, restrict_software_installation);
 
-  gtk_switch_set_active (self->restrict_system_installation_switch, restrict_system_installation);
-  gtk_switch_set_active (self->restrict_user_installation_switch, restrict_user_installation);
+  g_debug ("Restrict system installation: %s", restrict_software_installation ? "yes" : "no");
+  g_debug ("Restrict user installation: %s", restrict_software_installation ? "yes" : "no");
 
-  g_debug ("Restrict system installation: %s", restrict_system_installation ? "yes" : "no");
-  g_debug ("Restrict user installation: %s", restrict_user_installation ? "yes" : "no");
-
-  g_signal_handlers_unblock_by_func (self->restrict_system_installation_switch,
-                                     on_restrict_installation_switch_active_changed_cb,
-                                     self);
-
-  g_signal_handlers_unblock_by_func (self->restrict_user_installation_switch,
+  g_signal_handlers_unblock_by_func (self->restrict_software_installation_switch,
                                      on_restrict_installation_switch_active_changed_cb,
                                      self);
 }
@@ -534,12 +517,7 @@ update_labels_from_name (MctUserControls *self)
 
   /* Translators: The placeholder is a user’s display name. */
   l = g_strdup_printf (_("Prevents %s from installing applications."), self->user_display_name);
-  gtk_label_set_label (self->restrict_user_installation_description, l);
-  g_clear_pointer (&l, g_free);
-
-  /* Translators: The placeholder is a user’s display name. */
-  l = g_strdup_printf (_("Applications installed by %s will not appear for other users."), self->user_display_name);
-  gtk_label_set_label (self->restrict_system_installation_description, l);
+  gtk_label_set_label (self->restrict_software_installation_description, l);
   g_clear_pointer (&l, g_free);
 }
 
@@ -613,20 +591,6 @@ on_restrict_installation_switch_active_changed_cb (GtkSwitch        *s,
                                                    GParamSpec       *pspec,
                                                    MctUserControls *self)
 {
-  /* See the comment about policy in update_allow_app_installation(). */
-  if (s == self->restrict_user_installation_switch &&
-      gtk_switch_get_active (s) &&
-      !gtk_switch_get_active (self->restrict_system_installation_switch))
-    {
-      g_signal_handlers_block_by_func (self->restrict_system_installation_switch,
-                                       on_restrict_installation_switch_active_changed_cb,
-                                       self);
-      gtk_switch_set_active (self->restrict_system_installation_switch, TRUE);
-      g_signal_handlers_unblock_by_func (self->restrict_system_installation_switch,
-                                         on_restrict_installation_switch_active_changed_cb,
-                                         self);
-    }
-
   /* Save the changes. */
   schedule_update_blocklisted_apps (self);
 }
@@ -1066,10 +1030,8 @@ mct_user_controls_class_init (MctUserControlsClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/MalcontentUi/ui/user-controls.ui");
 
   gtk_widget_class_bind_template_child (widget_class, MctUserControls, age_menu);
-  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_system_installation_switch);
-  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_system_installation_description);
-  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_user_installation_switch);
-  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_user_installation_description);
+  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_software_installation_switch);
+  gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_software_installation_description);
   gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_web_browsers_switch);
   gtk_widget_class_bind_template_child (widget_class, MctUserControls, restrict_web_browsers_description);
   gtk_widget_class_bind_template_child (widget_class, MctUserControls, oars_button);
@@ -1122,10 +1084,6 @@ mct_user_controls_init (MctUserControls *self)
                                   G_ACTION_GROUP (self->action_group));
 
   gtk_popover_bind_model (self->oars_popover, G_MENU_MODEL (self->age_menu), NULL);
-
-  g_object_bind_property (self->restrict_user_installation_switch, "active",
-                          self->restrict_system_installation_switch, "sensitive",
-                          G_BINDING_DEFAULT | G_BINDING_INVERT_BOOLEAN);
 
   /* Automatically add separators between rows. */
   gtk_list_box_set_header_func (self->application_usage_permissions_listbox,
@@ -1554,16 +1512,14 @@ mct_user_controls_build_app_filter (MctUserControls     *self,
   /* App installation */
   if (self->user_account_type != ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR)
     {
-      gboolean restrict_system_installation;
-      gboolean restrict_user_installation;
+      gboolean restrict_software_installation;
 
-      restrict_system_installation = gtk_switch_get_active (self->restrict_system_installation_switch);
-      restrict_user_installation = gtk_switch_get_active (self->restrict_user_installation_switch);
+      restrict_software_installation = gtk_switch_get_active (self->restrict_software_installation_switch);
 
-      g_debug ("\t → %s system installation", restrict_system_installation ? "Restricting" : "Allowing");
-      g_debug ("\t → %s user installation", restrict_user_installation ? "Restricting" : "Allowing");
+      g_debug ("\t → %s system installation", restrict_software_installation ? "Restricting" : "Allowing");
+      g_debug ("\t → %s user installation", restrict_software_installation ? "Restricting" : "Allowing");
 
-      mct_app_filter_builder_set_allow_user_installation (builder, !restrict_user_installation);
-      mct_app_filter_builder_set_allow_system_installation (builder, !restrict_system_installation);
+      mct_app_filter_builder_set_allow_user_installation (builder, !restrict_software_installation);
+      mct_app_filter_builder_set_allow_system_installation (builder, !restrict_software_installation);
     }
 }

--- a/libmalcontent-ui/user-controls.ui
+++ b/libmalcontent-ui/user-controls.ui
@@ -255,7 +255,7 @@
             <property name="activate_on_single_click">False</property>
             <child>
               <object class="GtkListBoxRow">
-                <property name="visible" bind-source="restrict_user_installation_switch" bind-property="visible" bind-flags="default|sync-create" />
+                <property name="visible" bind-source="restrict_software_installation_switch" bind-property="visible" bind-flags="default|sync-create" />
                 <property name="can_focus">True</property>
                 <property name="activatable">False</property>
                 <property name="selectable">False</property>
@@ -271,7 +271,7 @@
                     <property name="row-spacing">4</property>
                     <property name="column-spacing">4</property>
                     <child>
-                      <object class="GtkLabel" id="restrict_user_installation_label">
+                      <object class="GtkLabel" id="restrict_software_installation_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
@@ -280,9 +280,9 @@
                         <property name="xalign">0</property>
                         <property name="label" translatable="yes">Restrict Application _Installation</property>
                         <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">restrict_user_installation_switch</property>
+                        <property name="mnemonic_widget">restrict_software_installation_switch</property>
                         <accessibility>
-                          <relation target="restrict_user_installation_switch" type="label-for"/>
+                          <relation target="restrict_software_installation_switch" type="label-for"/>
                         </accessibility>
                       </object>
                       <packing>
@@ -291,7 +291,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="restrict_user_installation_description">
+                      <object class="GtkLabel" id="restrict_software_installation_description">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">start</property>
@@ -308,7 +308,7 @@
                           <class name="dim-label" />
                         </style>
                         <accessibility>
-                          <relation target="restrict_user_installation_switch" type="description-for"/>
+                          <relation target="restrict_software_installation_switch" type="description-for"/>
                         </accessibility>
                       </object>
                       <packing>
@@ -317,92 +317,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkSwitch" id="restrict_user_installation_switch">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="halign">end</property>
-                        <property name="valign">center</property>
-                        <signal name="notify::active" handler="on_restrict_installation_switch_active_changed_cb" object="MctUserControls" swapped="no" />
-                        <style>
-                          <class name="restricts" />
-                        </style>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">0</property>
-                        <property name="height">2</property>
-                      </packing>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-
-            <child>
-              <object class="GtkListBoxRow">
-                <property name="visible" bind-source="restrict_system_installation_switch" bind-property="visible" bind-flags="default|sync-create" />
-                <property name="can_focus">True</property>
-                <property name="activatable">False</property>
-                <property name="selectable">False</property>
-                <child>
-                  <object class="GtkGrid">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="valign">center</property>
-                    <property name="margin-left">12</property>
-                    <property name="margin-right">12</property>
-                    <property name="margin-top">8</property>
-                    <property name="margin-bottom">8</property>
-                    <property name="row-spacing">4</property>
-                    <property name="column-spacing">4</property>
-                    <child>
-                      <object class="GtkLabel" id="restrict_system_installation_label">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="hexpand">True</property>
-                        <property name="ellipsize">end</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Restrict Application Installation for _Others</property>
-                        <property name="use_underline">True</property>
-                        <property name="mnemonic_widget">restrict_system_installation_switch</property>
-                        <accessibility>
-                          <relation target="restrict_system_installation_switch" type="label-for"/>
-                        </accessibility>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="restrict_system_installation_description">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">start</property>
-                        <property name="hexpand">True</property>
-                        <property name="ellipsize">none</property>
-                        <property name="wrap">True</property>
-                        <property name="xalign">0</property>
-                        <!-- Set dynamically from user-controls.c: -->
-                        <property name="label">Applications installed by {username} will not appear for other users.</property>
-                        <attributes>
-                          <attribute name="scale" value="0.88"/>
-                        </attributes>
-                        <style>
-                          <class name="dim-label" />
-                        </style>
-                        <accessibility>
-                          <relation target="restrict_system_installation_switch" type="description-for"/>
-                        </accessibility>
-                      </object>
-                      <packing>
-                        <property name="left-attach">0</property>
-                        <property name="top-attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSwitch" id="restrict_system_installation_switch">
+                      <object class="GtkSwitch" id="restrict_software_installation_switch">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="halign">end</property>
@@ -561,8 +476,7 @@
       <widget name="restrict_applications_label" />
       <widget name="restrict_applications_description" />
       <widget name="oars_label" />
-      <widget name="restrict_user_installation_label" />
-      <widget name="restrict_system_installation_label" />
+      <widget name="restrict_software_installation_label" />
     </widgets>
   </object>
 

--- a/malcontent-control/main.ui
+++ b/malcontent-control/main.ui
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.12"/>
   <object class="GtkApplicationWindow" id="main_window">
     <property name="default-width">500</property>
-    <property name="default-height">600</property>
+    <property name="default-height">520</property>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="header">
         <property name="show-close-button">True</property>


### PR DESCRIPTION
This simplifies the UI, as nobody really understood the difference
between ‘Restrict Application Installation’ and ‘Restrict Application
Installation for Others’. Now there’s just a ‘Restrict Application
Installation’ checkbox, which controls application installation in the
home and system flatpak repos.

The underlying app-filter representation in libmalcontent still supports
restricting installation to them separately, but the UI will always set
them to the same value.

There is a suggestion that we may want to support user repos again in
future iff the user has added a remote to their user repo. However,
figuring that out for other users (which is what the admin would have to
do when setting this all up) starts to get tricky with permissions for
reading other users’ home directories. Skip that for the moment — we can
reconsider adding that option in future if someone argues a case for it.

Signed-off-by: Philip Withnall <pwithnall@endlessos.org>

Fixes: #30
Upstream: https://gitlab.freedesktop.org/pwithnall/malcontent/-/merge_requests/105
https://phabricator.endlessm.com/T29923