### PR TITLE
T32618 Rebase on 0.10.2/upstream main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,7 +60,7 @@ debian:
 pages:
   stage: deploy
   only:
-    - master
+    - main
   script:
     - mv _coverage/ public/
   artifacts:

--- a/.gitlab-ci/cache-subprojects.sh
+++ b/.gitlab-ci/cache-subprojects.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-git clone https://gitlab.freedesktop.org/pwithnall/malcontent.git
+git clone --depth 1 --no-tags https://gitlab.freedesktop.org/pwithnall/malcontent.git
 meson subprojects download --sourcedir malcontent
 rm malcontent/subprojects/*.wrap
 mv malcontent/subprojects/ .

--- a/.gitlab-ci/meson-junit-report.py
+++ b/.gitlab-ci/meson-junit-report.py
@@ -24,7 +24,7 @@ aparser.add_argument('--job-id', metavar='ID',
                      default='Unknown')
 aparser.add_argument('--branch', metavar='NAME',
                      help='Branch of the project being tested',
-                     default='master')
+                     default='main')
 aparser.add_argument('--output', metavar='FILE',
                      help='The output file, stdout by default',
                      type=argparse.FileType('w', encoding='UTF-8'),

--- a/.tx/config
+++ b/.tx/config
@@ -1,0 +1,8 @@
+[main]
+host = https://www.transifex.com
+
+[malcontent.all]
+source_file = po/malcontent.pot
+source_lang = en
+file_filter = po/<lang>.po
+type = PO

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,17 @@
+Overview of changes in malcontent 0.10.1
+========================================
+
+* Bugs fixed:
+ - #32 App sort key does not match displayed name
+ - !112 Update Swedish translation
+ - !113 Update Polish translation 201220
+ - !116 libmalcontent-ui: Drop handling of eos-link desktop files
+
+* Translation updates:
+ - Polish
+ - Swedish
+
+
 Overview of changes in malcontent 0.10.0
 ========================================
 

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,19 @@
+Overview of changes in malcontent 0.10.2
+========================================
+
+* Hide the launcher for malcontent-control from gnome-shell if using the GNOME
+  desktop; find it via gnome-control-center instead (!119)
+
+* Bugs fixed:
+ - !118 ci: Limit depth of clone of subprojects
+ - !119 malcontent-control: Hide application in GNOME
+ - !121 ci: Rename master to main branch
+
+* Translation updates:
+ - Indonesian
+ - Italian
+
+
 Overview of changes in malcontent 0.10.1
 ========================================
 

--- a/help/id/id.po
+++ b/help/id/id.po
@@ -1,25 +1,25 @@
 # Indonesian translation for malcontent.
 # Copyright (C) 2020 malcontent's COPYRIGHT HOLDER
 # This file is distributed under the same license as the malcontent package.
-# Andika Triwidada <atriwidada@gnome.org>, 2020.
+# Andika Triwidada <andika@gmail.com>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent master\n"
-"POT-Creation-Date: 2020-04-11 15:30+0000\n"
-"PO-Revision-Date: 2020-04-12 17:20+0700\n"
+"POT-Creation-Date: 2020-12-18 15:14+0000\n"
+"PO-Revision-Date: 2021-08-30 18:26+0700\n"
+"Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <gnome-l10n-id@googlegroups.com>\n"
+"Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: id\n"
-"Last-Translator: Andika Triwidada <andika@gmail.com>\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #. Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
 msgctxt "_"
 msgid "translator-credits"
-msgstr "Andika Triwidada <andika@gmail.com>, 2020"
+msgstr "Andika Triwidada <andika@gmail.com>, 2020, 2021."
 
 #. (itstool) path: info/desc
 #: C/creating-a-child-user.page:6
@@ -117,13 +117,13 @@ msgstr "Untuk membatasi akses pengguna ke internet:"
 
 #. (itstool) path: item/p
 #: C/internet.page:19 C/restricting-applications.page:20
-#: C/software-installation.page:27 C/software-installation.page:64
+#: C/software-installation.page:28 C/software-installation.page:54
 msgid "Open the <app>Parental Controls</app> application."
 msgstr "Buka aplikasi <app>Pengawasan Orang Tua</app>."
 
 #. (itstool) path: item/p
 #: C/internet.page:20 C/restricting-applications.page:21
-#: C/software-installation.page:28 C/software-installation.page:65
+#: C/software-installation.page:29 C/software-installation.page:55
 msgid "Select the user in the tabs at the top."
 msgstr "Pilih pengguna di tab di bagian atas."
 
@@ -137,18 +137,21 @@ msgstr ""
 #. (itstool) path: info/desc
 #: C/introduction.page:6
 msgid ""
-"Overview of parental controls and the <app>Parental Controls</app> "
-"application."
+"Overview of parental controls, the <app>Parental Controls</app> application "
+"and its use in other situations where access restrictions are needed on a "
+"user."
 msgstr ""
-"Ikhtisar pengawasan orang tua dan aplikasi <app>Pengawasan Orang Tua</app>."
+"Ikhtisar pengawasan orang tua, aplikasi <app>Pengawasan Orang Tua</app>, dan "
+"penggunaannya dalam situasi lain dimana pembatasan akses diperlukan pada "
+"seorang pengguna."
 
 #. (itstool) path: page/title
-#: C/introduction.page:10
+#: C/introduction.page:12
 msgid "Introduction to Parental Controls"
 msgstr "Pengenalan untuk Pengawasan Orang Tua"
 
 #. (itstool) path: page/p
-#: C/introduction.page:12
+#: C/introduction.page:14
 msgid ""
 "Parental controls are a way to restrict what non-administrator accounts can "
 "do on the computer, with the aim of allowing parents to restrict what their "
@@ -161,18 +164,18 @@ msgstr ""
 "komputer tanpa pengawasan atau di bawah supervisi yang terbatas."
 
 #. (itstool) path: page/p
-#: C/introduction.page:16
+#: C/introduction.page:18
 msgid ""
 "This functionality can be used in other situations ­– such as other carer/"
 "caree relationships – but is labelled as ‘parental controls’ so that it’s "
-"easy to find."
+"easy to find, as that’s what most people will be looking for."
 msgstr ""
 "Fungsi ini dapat digunakan dalam situasi lain – seperti hubungan perawat/"
 "terrawat lainnya – tetapi diberi label sebagai 'pengawasan orang tua' "
-"sehingga mudah ditemukan."
+"sehingga mudah ditemukan, karena itulah yang kebanyakan orang akan cari."
 
 #. (itstool) path: page/p
-#: C/introduction.page:19
+#: C/introduction.page:21
 msgid ""
 "The parental controls for any user can be queried and set using the "
 "<app>Parental Controls</app> application. This lists the non-administrator "
@@ -186,7 +189,7 @@ msgstr ""
 "orang tua akan segera berlaku."
 
 #. (itstool) path: page/p
-#: C/introduction.page:23
+#: C/introduction.page:25
 msgid ""
 "Restrictions on using the computer can only be applied to non-administrator "
 "accounts. The parental controls settings for a user can only be changed by "
@@ -294,19 +297,20 @@ msgstr "Membatasi Instalasi Perangkat Lunak"
 #. (itstool) path: page/p
 #: C/software-installation.page:11
 msgid ""
-"You can prevent a user from installing additional software, either for the "
-"entire system, or just for themselves. They will still be able to search for "
-"new software to install, but will need an administrator to authorize the "
-"installation when they try to install an application."
+"You can prevent a user from installing additional software on the system. "
+"They will still be able to search for new software to install, but will need "
+"an administrator to authorize the installation when they try to install an "
+"application. This applies whether they are trying to install the application "
+"system-wide (for all users) or just for themselves."
 msgstr ""
-"Anda dapat mencegah pengguna dari menginstal perangkat lunak tambahan, baik "
+"Anda dapat mencegah pengguna dari memasang perangkat lunak tambahan, baik "
 "untuk seluruh sistem, atau hanya untuk diri mereka sendiri. Mereka masih "
-"akan dapat mencari perangkat lunak baru untuk diinstal, tetapi akan "
+"akan dapat mencari perangkat lunak baru untuk dipasang, tetapi akan "
 "memerlukan administrator untuk mengesahkan instalasi ketika mereka mencoba "
-"untuk menginstal aplikasi."
+"untuk memasang aplikasi."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:16
+#: C/software-installation.page:17
 msgid ""
 "Additionally, you can restrict which software a user can browse or search "
 "for in the <app>Software</app> catalog by age categories."
@@ -316,7 +320,7 @@ msgstr ""
 "kategori usia."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:19
+#: C/software-installation.page:20
 msgid ""
 "To prevent a user from running an application which has already been "
 "installed, see <link xref=\"restricting-applications\"/>."
@@ -325,17 +329,17 @@ msgstr ""
 "<link xref=\"restricting-applications\"/> ."
 
 #. (itstool) path: section/title
-#: C/software-installation.page:23
+#: C/software-installation.page:24
 msgid "Preventing Software Installation"
 msgstr "Mencegah Instalasi Perangkat Lunak"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:25
+#: C/software-installation.page:26
 msgid "To prevent a user from installing additional software:"
 msgstr "Untuk mencegah pengguna menginstal perangkat lunak tambahan:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:29
+#: C/software-installation.page:30
 msgid ""
 "Enable the <gui style=\"checkbox\">Restrict Application Installation</gui> "
 "checkbox."
@@ -343,45 +347,13 @@ msgstr ""
 "Fungsikan kotak centang <gui style=\"checkbox\">Batasi Pemasangan Aplikasi</"
 "gui>."
 
-#. (itstool) path: item/p
-#: C/software-installation.page:30
-msgid ""
-"Or enable the <gui style=\"checkbox\">Restrict Application Installation for "
-"Others</gui> checkbox."
-msgstr ""
-"Atau fungsikan kotak centang <gui style=\"checkbox\">Batasi Pemasangan "
-"Aplikasi untuk Orang Lain</gui>."
-
-#. (itstool) path: section/p
-#: C/software-installation.page:33
-msgid ""
-"The <gui style=\"checkbox\">Restrict Application Installation for Others</"
-"gui> checkbox allows the user to install additional software for themselves, "
-"but prevents that software from being made available to other users. It "
-"could be used, for example, if there were two child users, one of whom is "
-"mature enough to be allowed to install additional software, but the other "
-"isn’t — enabling <gui style=\"checkbox\">Restrict Application Installation "
-"for Others</gui> would prevent the more mature child from installing "
-"applications which are inappropriate for the other child and making them "
-"available to the other child."
-msgstr ""
-"Kotak centang <gui style=\"checkbox\">Batasi Pemasangan Aplikasi untuk Orang "
-"Lain</gui> memungkinkan pengguna untuk menginstal perangkat lunak tambahan "
-"untuk diri mereka sendiri, tetapi mencegah bahwa perangkat lunak yang dibuat "
-"tersedia untuk pengguna lain. Hal ini dapat digunakan, misalnya, jika ada "
-"dua pengguna anak, salah satunya cukup dewasa untuk diizinkan untuk "
-"menginstal perangkat lunak tambahan, tetapi yang lain tidak — memfungsikan "
-"<gui style=\"checkbox\">Batasi Pemasangan Aplikasi untuk Orang Lain</gui> "
-"akan mencegah anak yang lebih dewasa dari menginstal aplikasi yang tidak "
-"pantas untuk anak lain dan membuat mereka tersedia untuk anak lain."
-
 #. (itstool) path: section/title
-#: C/software-installation.page:45
+#: C/software-installation.page:35
 msgid "Restricting Software Installation by Age"
 msgstr "Membatasi Instalasi Perangkat Lunak berdasarkan Umur"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:47
+#: C/software-installation.page:37
 msgid ""
 "Applications in the <app>Software</app> catalog have information about "
 "content they contain which might be inappropriate for some ages — for "
@@ -394,7 +366,7 @@ msgstr ""
 "lain di internet, atau kemungkinan membelanjakan uang."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:51
+#: C/software-installation.page:41
 msgid ""
 "For each application, this information is summarized as the minimum age "
 "child it is typically suitable to be used by — for example, “suitable for "
@@ -407,7 +379,7 @@ msgstr ""
 "dibandingkan dengan skema penilaian yang digunakan untuk film dan permainan."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:55
+#: C/software-installation.page:45
 msgid ""
 "The applications shown to a user in the <app>Software</app> catalog can be "
 "filtered by their age suitability. Applications which are not suitable for "
@@ -421,7 +393,7 @@ msgstr ""
 "kesesuaian usia mereka ditetapkan cukup tinggi)."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:61
+#: C/software-installation.page:51
 msgid ""
 "To filter the applications seen by a user in the <app>Software</app> catalog "
 "to only those suitable for a certain age:"
@@ -430,7 +402,7 @@ msgstr ""
 "<app>Perangkat Lunak</app> agar hanya yang cocok untuk usia tertentu:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:66
+#: C/software-installation.page:56
 msgid ""
 "In the <gui>Application Suitability</gui> list, select the age which "
 "applications should be suitable for."
@@ -439,7 +411,7 @@ msgstr ""
 "cocok."
 
 #. (itstool) path: note/p
-#: C/software-installation.page:70
+#: C/software-installation.page:60
 msgid ""
 "The user’s actual age is not stored, so the <gui>Application Suitability</"
 "gui> is not automatically updated over time as the child grows older. You "

--- a/help/pl/pl.po
+++ b/help/pl/pl.po
@@ -7,14 +7,14 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent-help\n"
-"POT-Creation-Date: 2020-04-12 03:55+0000\n"
-"PO-Revision-Date: 2020-04-12 15:33+0200\n"
+"POT-Creation-Date: 2020-12-18 15:14+0000\n"
+"PO-Revision-Date: 2020-12-20 13:22+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <community-poland@mozilla.org>\n"
+"Language: pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: pl\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
@@ -123,13 +123,13 @@ msgstr "Aby ograniczyć dostęp użytkownika do Internetu:"
 
 #. (itstool) path: item/p
 #: C/internet.page:19 C/restricting-applications.page:20
-#: C/software-installation.page:27 C/software-installation.page:64
+#: C/software-installation.page:28 C/software-installation.page:54
 msgid "Open the <app>Parental Controls</app> application."
 msgstr "Otwórz program <app>Kontrola rodzicielska</app>."
 
 #. (itstool) path: item/p
 #: C/internet.page:20 C/restricting-applications.page:21
-#: C/software-installation.page:28 C/software-installation.page:65
+#: C/software-installation.page:29 C/software-installation.page:55
 msgid "Select the user in the tabs at the top."
 msgstr "Wybierz użytkownika z kart na górze."
 
@@ -144,18 +144,21 @@ msgstr ""
 #. (itstool) path: info/desc
 #: C/introduction.page:6
 msgid ""
-"Overview of parental controls and the <app>Parental Controls</app> "
-"application."
+"Overview of parental controls, the <app>Parental Controls</app> application "
+"and its use in other situations where access restrictions are needed on a "
+"user."
 msgstr ""
-"Przegląd kontroli rodzicielskiej i programu <app>Kontrola rodzicielska</app>."
+"Przegląd kontroli rodzicielskiej, programu <app>Kontrola rodzicielska</app> "
+"i jego użycia w innych sytuacjach, w których potrzebne są ograniczenia "
+"dostępu użytkownika."
 
 #. (itstool) path: page/title
-#: C/introduction.page:10
+#: C/introduction.page:12
 msgid "Introduction to Parental Controls"
 msgstr "Wprowadzenie do kontroli rodzicielskiej"
 
 #. (itstool) path: page/p
-#: C/introduction.page:12
+#: C/introduction.page:14
 msgid ""
 "Parental controls are a way to restrict what non-administrator accounts can "
 "do on the computer, with the aim of allowing parents to restrict what their "
@@ -168,18 +171,18 @@ msgstr ""
 "nadzoru lub z minimalnym nadzorem."
 
 #. (itstool) path: page/p
-#: C/introduction.page:16
+#: C/introduction.page:18
 msgid ""
 "This functionality can be used in other situations ­– such as other carer/"
 "caree relationships – but is labelled as ‘parental controls’ so that it’s "
-"easy to find."
+"easy to find, as that’s what most people will be looking for."
 msgstr ""
 "Ta funkcjonalność może być używana w innych sytuacjach — takich jak inne "
 "relacje opiekuńcze — ale nazywa się „kontrola rodzicielska”, aby można ją "
-"było łatwo znaleźć."
+"było łatwo znaleźć, jako że większość osób będzie szukać tego terminu."
 
 #. (itstool) path: page/p
-#: C/introduction.page:19
+#: C/introduction.page:21
 msgid ""
 "The parental controls for any user can be queried and set using the "
 "<app>Parental Controls</app> application. This lists the non-administrator "
@@ -193,7 +196,7 @@ msgstr ""
 "są uwzględniane od razu."
 
 #. (itstool) path: page/p
-#: C/introduction.page:23
+#: C/introduction.page:25
 msgid ""
 "Restrictions on using the computer can only be applied to non-administrator "
 "accounts. The parental controls settings for a user can only be changed by "
@@ -305,18 +308,20 @@ msgstr "Ograniczanie instalacji oprogramowania"
 #. (itstool) path: page/p
 #: C/software-installation.page:11
 msgid ""
-"You can prevent a user from installing additional software, either for the "
-"entire system, or just for themselves. They will still be able to search for "
-"new software to install, but will need an administrator to authorize the "
-"installation when they try to install an application."
+"You can prevent a user from installing additional software on the system. "
+"They will still be able to search for new software to install, but will need "
+"an administrator to authorize the installation when they try to install an "
+"application. This applies whether they are trying to install the application "
+"system-wide (for all users) or just for themselves."
 msgstr ""
-"Można uniemożliwić użytkownikowi instalowanie dodatkowego oprogramowania dla "
-"całego komputera lub tylko dla niego. Nadal będzie on mógł wyszukiwać nowe "
-"oprogramowanie, ale do jego zainstalowania będzie potrzebował upoważnienia "
-"administratora."
+"Można uniemożliwić użytkownikowi instalowanie dodatkowego oprogramowania na "
+"komputerze. Nadal będzie on mógł wyszukiwać nowe oprogramowanie, ale do jego "
+"zainstalowania będzie potrzebował upoważnienia administratora. Ma to "
+"zastosowanie niezależnie od tego, czy użytkownik próbuje zainstalować "
+"program w systemie (dla wszystkich użytkowników) czy tylko dla siebie."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:16
+#: C/software-installation.page:17
 msgid ""
 "Additionally, you can restrict which software a user can browse or search "
 "for in the <app>Software</app> catalog by age categories."
@@ -326,7 +331,7 @@ msgstr ""
 "wiekowych."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:19
+#: C/software-installation.page:20
 msgid ""
 "To prevent a user from running an application which has already been "
 "installed, see <link xref=\"restricting-applications\"/>."
@@ -335,63 +340,31 @@ msgstr ""
 "uniemożliwić użytkownikowi uruchamianie już zainstalowanego programu."
 
 #. (itstool) path: section/title
-#: C/software-installation.page:23
+#: C/software-installation.page:24
 msgid "Preventing Software Installation"
 msgstr "Uniemożliwianie instalacji oprogramowania"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:25
+#: C/software-installation.page:26
 msgid "To prevent a user from installing additional software:"
 msgstr ""
 "Aby uniemożliwić użytkownikowi instalowanie dodatkowego oprogramowania:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:29
+#: C/software-installation.page:30
 msgid ""
 "Enable the <gui style=\"checkbox\">Restrict Application Installation</gui> "
 "checkbox."
 msgstr ""
 "Zaznacz pole <gui style=\"checkbox\">Ograniczanie instalacji programów</gui>."
 
-#. (itstool) path: item/p
-#: C/software-installation.page:30
-msgid ""
-"Or enable the <gui style=\"checkbox\">Restrict Application Installation for "
-"Others</gui> checkbox."
-msgstr ""
-"Lub zaznacz pole <gui style=\"checkbox\">Ograniczanie instalacji programów "
-"dla innych</gui>."
-
-#. (itstool) path: section/p
-#: C/software-installation.page:33
-msgid ""
-"The <gui style=\"checkbox\">Restrict Application Installation for Others</"
-"gui> checkbox allows the user to install additional software for themselves, "
-"but prevents that software from being made available to other users. It "
-"could be used, for example, if there were two child users, one of whom is "
-"mature enough to be allowed to install additional software, but the other "
-"isn’t — enabling <gui style=\"checkbox\">Restrict Application Installation "
-"for Others</gui> would prevent the more mature child from installing "
-"applications which are inappropriate for the other child and making them "
-"available to the other child."
-msgstr ""
-"Pole <gui style=\"checkbox\">Ograniczanie instalacji programów dla innych</"
-"gui> umożliwia użytkownikowi instalowanie dodatkowego oprogramowania dla "
-"siebie, ale uniemożliwia korzystanie z tego oprogramowania pozostałym "
-"użytkownikom. Można go używać na przykład jeśli są dwa konta dzieci, "
-"z których jedno na tyle dorosłe, aby móc instalować dodatkowe "
-"oprogramowanie, ale drugie nie jest — włączenie <gui style=\"checkbox"
-"\">Ograniczanie instalacji programów dla innych</gui> uniemożliwi starszemu "
-"dziecku instalowanie programów nieodpowiednich dla młodszego i dawanie mu do "
-"nich dostępu."
-
 #. (itstool) path: section/title
-#: C/software-installation.page:45
+#: C/software-installation.page:35
 msgid "Restricting Software Installation by Age"
 msgstr "Ograniczanie instalacji oprogramowania według wieku"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:47
+#: C/software-installation.page:37
 msgid ""
 "Applications in the <app>Software</app> catalog have information about "
 "content they contain which might be inappropriate for some ages — for "
@@ -404,7 +377,7 @@ msgstr ""
 "w Internecie lub możliwość wydawania pieniędzy."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:51
+#: C/software-installation.page:41
 msgid ""
 "For each application, this information is summarized as the minimum age "
 "child it is typically suitable to be used by — for example, “suitable for "
@@ -418,7 +391,7 @@ msgstr ""
 "filmów i gier."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:55
+#: C/software-installation.page:45
 msgid ""
 "The applications shown to a user in the <app>Software</app> catalog can be "
 "filtered by their age suitability. Applications which are not suitable for "
@@ -432,7 +405,7 @@ msgstr ""
 "kategoria wiekowa jest ustawiona odpowiednio wysoko)."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:61
+#: C/software-installation.page:51
 msgid ""
 "To filter the applications seen by a user in the <app>Software</app> catalog "
 "to only those suitable for a certain age:"
@@ -441,7 +414,7 @@ msgstr ""
 "<app>Menedżera oprogramowania</app>:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:66
+#: C/software-installation.page:56
 msgid ""
 "In the <gui>Application Suitability</gui> list, select the age which "
 "applications should be suitable for."
@@ -450,7 +423,7 @@ msgstr ""
 "programy powinny być odpowiednie."
 
 #. (itstool) path: note/p
-#: C/software-installation.page:70
+#: C/software-installation.page:60
 msgid ""
 "The user’s actual age is not stored, so the <gui>Application Suitability</"
 "gui> is not automatically updated over time as the child grows older. You "

--- a/help/sv/sv.po
+++ b/help/sv/sv.po
@@ -6,16 +6,16 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent master\n"
-"POT-Creation-Date: 2020-09-13 15:28+0000\n"
-"PO-Revision-Date: 2020-09-14 15:22+0200\n"
+"POT-Creation-Date: 2020-12-08 15:28+0000\n"
+"PO-Revision-Date: 2020-12-17 18:25+0100\n"
+"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: sv\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #. Put one translator per line, in the form NAME <EMAIL>, YEAR1, YEAR2
 msgctxt "_"
@@ -118,13 +118,13 @@ msgstr "För att begränsa en användares åtkomst till internet:"
 
 #. (itstool) path: item/p
 #: C/internet.page:19 C/restricting-applications.page:20
-#: C/software-installation.page:27 C/software-installation.page:64
+#: C/software-installation.page:28 C/software-installation.page:54
 msgid "Open the <app>Parental Controls</app> application."
 msgstr "Öppna programmet <app>Föräldrakontroller</app>."
 
 #. (itstool) path: item/p
 #: C/internet.page:20 C/restricting-applications.page:21
-#: C/software-installation.page:28 C/software-installation.page:65
+#: C/software-installation.page:29 C/software-installation.page:55
 msgid "Select the user in the tabs at the top."
 msgstr "Välj användaren i flikarna högst upp."
 
@@ -137,19 +137,21 @@ msgstr "Aktivera kryssrutan <gui style=\"checkbox\">Begränsa webbläsare</gui>.
 #. (itstool) path: info/desc
 #: C/introduction.page:6
 msgid ""
-"Overview of parental controls and the <app>Parental Controls</app> "
-"application."
+"Overview of parental controls, the <app>Parental Controls</app> application "
+"and its use in other situations where access restrictions are needed on a "
+"user."
 msgstr ""
-"Översikt över föräldrakontroller och programmet <app>Föräldrakontroller</"
-"app>."
+"Översikt över föräldrakontroller, programmet <app>Föräldrakontroller</app> "
+"och dess användning i andra situationer där åtkomstbegränsningar behövs för "
+"en användare."
 
 #. (itstool) path: page/title
-#: C/introduction.page:10
+#: C/introduction.page:12
 msgid "Introduction to Parental Controls"
 msgstr "Introduktion till Föräldrakontroller"
 
 #. (itstool) path: page/p
-#: C/introduction.page:12
+#: C/introduction.page:14
 msgid ""
 "Parental controls are a way to restrict what non-administrator accounts can "
 "do on the computer, with the aim of allowing parents to restrict what their "
@@ -161,18 +163,19 @@ msgstr ""
 "göra när de använder datorn utan översikt eller med begränsad översikt."
 
 #. (itstool) path: page/p
-#: C/introduction.page:16
+#: C/introduction.page:18
 msgid ""
 "This functionality can be used in other situations ­– such as other carer/"
 "caree relationships – but is labelled as ‘parental controls’ so that it’s "
-"easy to find."
+"easy to find, as that’s what most people will be looking for."
 msgstr ""
 "Denna funktionalitet kan användas i andra situationer – som i andra "
 "relationer där ena parten har ansvar för den andra – men kallas "
-"”föräldrakontroller” för att vara lätt att hitta."
+"”föräldrakontroller” för att vara lätt att hitta, då det är vad de flesta "
+"kommer att söka efter."
 
 #. (itstool) path: page/p
-#: C/introduction.page:19
+#: C/introduction.page:21
 msgid ""
 "The parental controls for any user can be queried and set using the "
 "<app>Parental Controls</app> application. This lists the non-administrator "
@@ -186,7 +189,7 @@ msgstr ""
 "föräldrakontrollerna tillämpas omedelbart."
 
 #. (itstool) path: page/p
-#: C/introduction.page:23
+#: C/introduction.page:25
 msgid ""
 "Restrictions on using the computer can only be applied to non-administrator "
 "accounts. The parental controls settings for a user can only be changed by "
@@ -294,19 +297,21 @@ msgstr "Begränsa installation av programvara"
 #. (itstool) path: page/p
 #: C/software-installation.page:11
 msgid ""
-"You can prevent a user from installing additional software, either for the "
-"entire system, or just for themselves. They will still be able to search for "
-"new software to install, but will need an administrator to authorize the "
-"installation when they try to install an application."
+"You can prevent a user from installing additional software on the system. "
+"They will still be able to search for new software to install, but will need "
+"an administrator to authorize the installation when they try to install an "
+"application. This applies whether they are trying to install the application "
+"system-wide (for all users) or just for themselves."
 msgstr ""
-"Du kan förhindra en användare från att installera ytterligare programvara, "
-"antingen för hela systemet, eller bara för sig själva. De kommer fortfarande "
-"kunna söka efter ny programvara att installera, men kommer behöva att en "
-"administratör godkänner installationen när de försöker installera ett "
-"program."
+"Du kan förhindra en användare från att installera ytterligare programvara på "
+"systemet. De kommer fortfarande kunna söka efter ny programvara att "
+"installera, men kommer behöva att en administratör godkänner installationen "
+"när de försöker installera ett program. Detta gäller oavsett om de försöker "
+"installera programmet systemomfattande (för alla användare) eller bara för "
+"sig själva."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:16
+#: C/software-installation.page:17
 msgid ""
 "Additionally, you can restrict which software a user can browse or search "
 "for in the <app>Software</app> catalog by age categories."
@@ -316,7 +321,7 @@ msgstr ""
 "ålderskategorier."
 
 #. (itstool) path: page/p
-#: C/software-installation.page:19
+#: C/software-installation.page:20
 msgid ""
 "To prevent a user from running an application which has already been "
 "installed, see <link xref=\"restricting-applications\"/>."
@@ -325,18 +330,18 @@ msgstr ""
 "installerats, se <link xref=\"restricting-applications\"/>."
 
 #. (itstool) path: section/title
-#: C/software-installation.page:23
+#: C/software-installation.page:24
 msgid "Preventing Software Installation"
 msgstr "Förhindra installation av programvara"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:25
+#: C/software-installation.page:26
 msgid "To prevent a user from installing additional software:"
 msgstr ""
 "För att förhindra en användare från att installera ytterligare programvara:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:29
+#: C/software-installation.page:30
 msgid ""
 "Enable the <gui style=\"checkbox\">Restrict Application Installation</gui> "
 "checkbox."
@@ -344,45 +349,13 @@ msgstr ""
 "Aktivera kryssrutan <gui style=\"checkbox\">Begränsa installation av "
 "program</gui>."
 
-#. (itstool) path: item/p
-#: C/software-installation.page:30
-msgid ""
-"Or enable the <gui style=\"checkbox\">Restrict Application Installation for "
-"Others</gui> checkbox."
-msgstr ""
-"Eller aktivera kryssrutan <gui style=\"checkbox\">Begränsa installation av "
-"program åt andra</gui>."
-
-#. (itstool) path: section/p
-#: C/software-installation.page:33
-msgid ""
-"The <gui style=\"checkbox\">Restrict Application Installation for Others</"
-"gui> checkbox allows the user to install additional software for themselves, "
-"but prevents that software from being made available to other users. It "
-"could be used, for example, if there were two child users, one of whom is "
-"mature enough to be allowed to install additional software, but the other "
-"isn’t — enabling <gui style=\"checkbox\">Restrict Application Installation "
-"for Others</gui> would prevent the more mature child from installing "
-"applications which are inappropriate for the other child and making them "
-"available to the other child."
-msgstr ""
-"Kryssrutan <gui style=\"checkbox\">Begränsa installation av program åt "
-"andra</gui> låter användaren installera ytterligare programvara åt sig "
-"själv, men förhindrar den programvaran från att bli tillgänglig för andra "
-"användare. Det kan till exempel användas om det finns två barnanvändare, en "
-"som är mogen nog för att tillåtas installera ytterligare programvara, och en "
-"som inte är det — att aktivera <gui style=\"checkbox\">Begränsa installation "
-"av program åt andra</gui> skulle förhindra det mognare barnet från att "
-"installera program som är olämpliga så att de blir tillgängliga för det "
-"andra barnet."
-
 #. (itstool) path: section/title
-#: C/software-installation.page:45
+#: C/software-installation.page:35
 msgid "Restricting Software Installation by Age"
 msgstr "Begränsning av programvaruinstallation enligt ålder"
 
 #. (itstool) path: section/p
-#: C/software-installation.page:47
+#: C/software-installation.page:37
 msgid ""
 "Applications in the <app>Software</app> catalog have information about "
 "content they contain which might be inappropriate for some ages — for "
@@ -395,7 +368,7 @@ msgstr ""
 "att spendera pengar."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:51
+#: C/software-installation.page:41
 msgid ""
 "For each application, this information is summarized as the minimum age "
 "child it is typically suitable to be used by — for example, “suitable for "
@@ -408,7 +381,7 @@ msgstr ""
 "kan jämföras med klassifikationerna som används för film och spel."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:55
+#: C/software-installation.page:45
 msgid ""
 "The applications shown to a user in the <app>Software</app> catalog can be "
 "filtered by their age suitability. Applications which are not suitable for "
@@ -422,7 +395,7 @@ msgstr ""
 "är satt tillräckligt högt)."
 
 #. (itstool) path: section/p
-#: C/software-installation.page:61
+#: C/software-installation.page:51
 msgid ""
 "To filter the applications seen by a user in the <app>Software</app> catalog "
 "to only those suitable for a certain age:"
@@ -432,7 +405,7 @@ msgstr ""
 "ålder:"
 
 #. (itstool) path: item/p
-#: C/software-installation.page:66
+#: C/software-installation.page:56
 msgid ""
 "In the <gui>Application Suitability</gui> list, select the age which "
 "applications should be suitable for."
@@ -441,7 +414,7 @@ msgstr ""
 "vara lämpliga för."
 
 #. (itstool) path: note/p
-#: C/software-installation.page:70
+#: C/software-installation.page:60
 msgid ""
 "The user’s actual age is not stored, so the <gui>Application Suitability</"
 "gui> is not automatically updated over time as the child grows older. You "
@@ -452,3 +425,31 @@ msgstr ""
 "uppdateras inte automatiskt då barnet blir äldre. Du måste periodiskt "
 "utvärdera den rätta <gui>Lämplighet för program</gui> för varje användare på "
 "nytt."
+
+#~ msgid ""
+#~ "Or enable the <gui style=\"checkbox\">Restrict Application Installation "
+#~ "for Others</gui> checkbox."
+#~ msgstr ""
+#~ "Eller aktivera kryssrutan <gui style=\"checkbox\">Begränsa installation "
+#~ "av program åt andra</gui>."
+
+#~ msgid ""
+#~ "The <gui style=\"checkbox\">Restrict Application Installation for Others</"
+#~ "gui> checkbox allows the user to install additional software for "
+#~ "themselves, but prevents that software from being made available to other "
+#~ "users. It could be used, for example, if there were two child users, one "
+#~ "of whom is mature enough to be allowed to install additional software, "
+#~ "but the other isn’t — enabling <gui style=\"checkbox\">Restrict "
+#~ "Application Installation for Others</gui> would prevent the more mature "
+#~ "child from installing applications which are inappropriate for the other "
+#~ "child and making them available to the other child."
+#~ msgstr ""
+#~ "Kryssrutan <gui style=\"checkbox\">Begränsa installation av program åt "
+#~ "andra</gui> låter användaren installera ytterligare programvara åt sig "
+#~ "själv, men förhindrar den programvaran från att bli tillgänglig för andra "
+#~ "användare. Det kan till exempel användas om det finns två barnanvändare, "
+#~ "en som är mogen nog för att tillåtas installera ytterligare programvara, "
+#~ "och en som inte är det — att aktivera <gui style=\"checkbox\">Begränsa "
+#~ "installation av program åt andra</gui> skulle förhindra det mognare "
+#~ "barnet från att installera program som är olämpliga så att de blir "
+#~ "tillgängliga för det andra barnet."

--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -374,8 +374,8 @@ compare_app_info_cb (gconstpointer a,
   GAppInfo *app_a = (GAppInfo*) a;
   GAppInfo *app_b = (GAppInfo*) b;
 
-  return g_utf8_collate (g_app_info_get_display_name (app_a),
-                         g_app_info_get_display_name (app_b));
+  return g_utf8_collate (g_app_info_get_name (app_a),
+                         g_app_info_get_name (app_b));
 }
 
 static gint

--- a/libmalcontent-ui/restrict-applications-selector.c
+++ b/libmalcontent-ui/restrict-applications-selector.c
@@ -521,8 +521,6 @@ reload_apps (MctRestrictApplicationsSelector *self)
       if (!G_IS_DESKTOP_APP_INFO (app) ||
           !g_app_info_should_show (app) ||
           app_name[0] == '\0' ||
-          /* Endless' link apps have the "eos-link" prefix, and should be ignored too */
-          g_str_has_prefix (g_app_info_get_id (app), "eos-link") ||
           /* FIXME: Only list flatpak apps and apps with X-Parental-Controls
            * key set for now; we really need a system-wide MAC to be able to
            * reliably support blocklisting system programs. */

--- a/libmalcontent-ui/user-controls.c
+++ b/libmalcontent-ui/user-controls.c
@@ -711,6 +711,31 @@ list_box_header_func (GtkListBoxRow *row,
     }
 }
 
+static gboolean
+on_keynav_failed (GtkWidget        *listbox,
+                  GtkDirectionType  direction,
+                  gpointer          user_data)
+{
+  MctUserControls *self = MCT_USER_CONTROLS (user_data);
+  GtkWidget *new_widget = NULL;
+
+  /* There are currently two listboxes, so don’t over-complicate this function. */
+  if (listbox == GTK_WIDGET (self->application_usage_permissions_listbox) &&
+      direction == GTK_DIR_DOWN)
+    new_widget = GTK_WIDGET (self->software_installation_permissions_listbox);
+  else if (listbox == GTK_WIDGET (self->software_installation_permissions_listbox) &&
+           direction == GTK_DIR_UP)
+    new_widget = GTK_WIDGET (self->application_usage_permissions_listbox);
+
+  if (new_widget != NULL)
+    {
+      gtk_widget_child_focus (new_widget, direction);
+      return TRUE;
+    }
+
+  return FALSE;
+}
+
 /* GObject overrides */
 
 static void
@@ -1031,6 +1056,7 @@ mct_user_controls_class_init (MctUserControlsClass *klass)
   gtk_widget_class_bind_template_callback (widget_class, on_restrict_applications_dialog_delete_event_cb);
   gtk_widget_class_bind_template_callback (widget_class, on_restrict_applications_dialog_response_cb);
   gtk_widget_class_bind_template_callback (widget_class, on_application_usage_permissions_listbox_activated_cb);
+  gtk_widget_class_bind_template_callback (widget_class, on_keynav_failed);
 }
 
 static void

--- a/libmalcontent-ui/user-controls.ui
+++ b/libmalcontent-ui/user-controls.ui
@@ -39,6 +39,7 @@
             <property name="selection_mode">none</property>
             <property name="activate-on-single-click">True</property>
             <signal name="row-activated" handler="on_application_usage_permissions_listbox_activated_cb" object="MctUserControls" swapped="no" />
+            <signal name="keynav-failed" handler="on_keynav_failed" object="MctUserControls" swapped="no" />
             <child>
               <object class="GtkListBoxRow">
                 <property name="visible">True</property>
@@ -252,6 +253,7 @@
             <property name="hexpand">True</property>
             <property name="selection_mode">none</property>
             <property name="activate_on_single_click">False</property>
+            <signal name="keynav-failed" handler="on_keynav_failed" object="MctUserControls" swapped="no" />
             <child>
               <object class="GtkListBoxRow">
                 <property name="visible" bind-source="restrict_software_installation_switch" bind-property="visible" bind-flags="default|sync-create" />

--- a/libmalcontent/tests/app-filter.c
+++ b/libmalcontent/tests/app-filter.c
@@ -675,6 +675,12 @@ bus_set_up (BusFixture    *fixture,
   g_assert_no_error (local_error);
 
   gt_dbus_queue_export_object (fixture->queue,
+                               object_path,
+                               (GDBusInterfaceInfo *) &org_freedesktop_accounts_user_interface,
+                               &local_error);
+  g_assert_no_error (local_error);
+
+  gt_dbus_queue_export_object (fixture->queue,
                                "/org/freedesktop/Accounts",
                                (GDBusInterfaceInfo *) &org_freedesktop_accounts_interface,
                                &local_error);
@@ -708,9 +714,17 @@ async_result_cb (GObject      *obj,
  * given in #GetAppFilterData.properties if queried for a UID matching
  * #GetAppFilterData.expected_uid. Intended to be used for writing ‘successful’
  * mct_manager_get_app_filter() tests returning a variety of values. */
+typedef enum
+{
+  /* Copied from accounts-service: */
+  ACCOUNT_TYPE_NORMAL = 0,
+  ACCOUNT_TYPE_ADMINISTRATOR = 1,
+} AccountType;
+
 typedef struct
 {
   uid_t expected_uid;
+  gint32 account_type;
   const gchar *properties;
 } GetAppFilterData;
 
@@ -722,6 +736,7 @@ get_app_filter_server_cb (GtDBusQueue *queue,
   const GetAppFilterData *data = user_data;
   g_autoptr(GDBusMethodInvocation) invocation1 = NULL;
   g_autoptr(GDBusMethodInvocation) invocation2 = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation3 = NULL;
   g_autofree gchar *object_path = NULL;
   g_autoptr(GVariant) properties_variant = NULL;
 
@@ -750,6 +765,21 @@ get_app_filter_server_cb (GtDBusQueue *queue,
   properties_variant = g_variant_ref_sink (g_variant_new_parsed (data->properties));
   g_dbus_method_invocation_return_value (invocation2,
                                          g_variant_new_tuple (&properties_variant, 1));
+
+  /* Handle the Properties.Get() call for the AccountType, and say the account
+   * is a normal user or admin (depending on `data->account_type`). */
+  const gchar *property_name;
+  invocation3 =
+      gt_dbus_queue_assert_pop_message (queue,
+                                        object_path,
+                                        "org.freedesktop.DBus.Properties",
+                                        "Get", "(&s&s)",
+                                        &property_interface, &property_name);
+  g_assert_cmpstr (property_interface, ==, "org.freedesktop.Accounts.User");
+  g_assert_cmpstr (property_name, ==, "AccountType");
+
+  g_dbus_method_invocation_return_value (invocation3,
+                                         g_variant_new_parsed ("(<%i>,)", data->account_type));
 }
 
 /* Test that getting an #MctAppFilter from the mock D-Bus service works. The
@@ -768,6 +798,7 @@ test_app_filter_bus_get (BusFixture    *fixture,
   const GetAppFilterData get_app_filter_data =
     {
       .expected_uid = fixture->valid_uid,
+      .account_type = ACCOUNT_TYPE_NORMAL,
       .properties = "{"
         "'AllowUserInstallation': <true>,"
         "'AllowSystemInstallation': <false>,"
@@ -824,6 +855,7 @@ test_app_filter_bus_get_allowlist (BusFixture    *fixture,
   const GetAppFilterData get_app_filter_data =
     {
       .expected_uid = fixture->valid_uid,
+      .account_type = ACCOUNT_TYPE_NORMAL,
       .properties = "{"
         "'AllowUserInstallation': <true>,"
         "'AllowSystemInstallation': <true>,"
@@ -879,6 +911,7 @@ test_app_filter_bus_get_all_oars_values (BusFixture    *fixture,
   const GetAppFilterData get_app_filter_data =
     {
       .expected_uid = fixture->valid_uid,
+      .account_type = ACCOUNT_TYPE_NORMAL,
       .properties = "{"
         "'AllowUserInstallation': <true>,"
         "'AllowSystemInstallation': <true>,"
@@ -936,6 +969,7 @@ test_app_filter_bus_get_defaults (BusFixture    *fixture,
   const GetAppFilterData get_app_filter_data =
     {
       .expected_uid = fixture->valid_uid,
+      .account_type = ACCOUNT_TYPE_NORMAL,
       .properties = "{"
         "'AppFilter': <(false, @as [])>"
       "}"
@@ -962,6 +996,50 @@ test_app_filter_bus_get_defaults (BusFixture    *fixture,
                    MCT_APP_FILTER_OARS_VALUE_UNKNOWN);
   g_assert_true (mct_app_filter_is_user_installation_allowed (app_filter));
   g_assert_false (mct_app_filter_is_system_installation_allowed (app_filter));
+}
+
+/* As with test_app_filter_bus_get_defaults(), but check that the default value
+ * for mct_app_filter_is_system_installation_allowed() is true for
+ * administrators.
+ *
+ * NOTE: This is a downstream Endless addition.
+ *
+ * The mock D-Bus replies are generated in get_app_filter_server_cb(). */
+static void
+test_app_filter_bus_get_defaults_administrator (BusFixture    *fixture,
+                                                gconstpointer  test_data)
+{
+  g_autoptr(MctAppFilter) app_filter = NULL;
+  g_autoptr(GError) local_error = NULL;
+  const GetAppFilterData get_app_filter_data =
+    {
+      .expected_uid = fixture->valid_uid,
+      .account_type = ACCOUNT_TYPE_ADMINISTRATOR,
+      .properties = "{"
+        "'AppFilter': <(false, @as [])>"
+      "}"
+    };
+  g_autofree const gchar **oars_sections = NULL;
+
+  gt_dbus_queue_set_server_func (fixture->queue, get_app_filter_server_cb,
+                                 (gpointer) &get_app_filter_data);
+
+  app_filter = mct_manager_get_app_filter (fixture->manager,
+                                           fixture->valid_uid,
+                                           MCT_GET_APP_FILTER_FLAGS_NONE, NULL,
+                                           &local_error);
+
+  g_assert_no_error (local_error);
+  g_assert_nonnull (app_filter);
+
+  /* Check the default values for the properties. */
+  g_assert_cmpuint (mct_app_filter_get_user_id (app_filter), ==, fixture->valid_uid);
+  oars_sections = mct_app_filter_get_oars_sections (app_filter);
+  g_assert_cmpuint (g_strv_length ((gchar **) oars_sections), ==, 0);
+  g_assert_cmpint (mct_app_filter_get_oars_value (app_filter, "violence-bloodshed"), ==,
+                   MCT_APP_FILTER_OARS_VALUE_UNKNOWN);
+  g_assert_true (mct_app_filter_is_user_installation_allowed (app_filter));
+  g_assert_true (mct_app_filter_is_system_installation_allowed (app_filter));
 }
 
 /* Test that mct_manager_get_app_filter() returns an appropriate error if the
@@ -1078,6 +1156,7 @@ test_app_filter_bus_get_error_permission_denied_missing (BusFixture    *fixture,
   g_autoptr(GError) local_error = NULL;
   g_autoptr(GDBusMethodInvocation) invocation1 = NULL;
   g_autoptr(GDBusMethodInvocation) invocation2 = NULL;
+  g_autoptr(GDBusMethodInvocation) invocation3 = NULL;
   g_autofree gchar *object_path = NULL;
   g_autoptr(MctAppFilter) app_filter = NULL;
 
@@ -1111,6 +1190,21 @@ test_app_filter_bus_get_error_permission_denied_missing (BusFixture    *fixture,
   g_assert_cmpstr (property_interface, ==, "com.endlessm.ParentalControls.AppFilter");
 
   g_dbus_method_invocation_return_value (invocation2, g_variant_new ("(a{sv})", NULL));
+
+  /* Handle the Properties.Get() call for the AccountType, and say the account
+   * is a normal user. */
+  const gchar *property_name;
+  invocation3 =
+      gt_dbus_queue_assert_pop_message (fixture->queue,
+                                        object_path,
+                                        "org.freedesktop.DBus.Properties",
+                                        "Get", "(&s&s)",
+                                        &property_interface, &property_name);
+  g_assert_cmpstr (property_interface, ==, "org.freedesktop.Accounts.User");
+  g_assert_cmpstr (property_name, ==, "AccountType");
+
+  g_dbus_method_invocation_return_value (invocation3,
+                                         g_variant_new_parsed ("(<%i>,)", ACCOUNT_TYPE_NORMAL));
 
   /* Get the get_app_filter() result. */
   while (result == NULL)
@@ -1619,6 +1713,8 @@ main (int    argc,
               bus_set_up, test_app_filter_bus_get_all_oars_values, bus_tear_down);
   g_test_add ("/app-filter/bus/get/defaults", BusFixture, NULL,
               bus_set_up, test_app_filter_bus_get_defaults, bus_tear_down);
+  g_test_add ("/app-filter/bus/get/defaults/administrator", BusFixture, NULL,
+              bus_set_up, test_app_filter_bus_get_defaults_administrator, bus_tear_down);
 
   g_test_add ("/app-filter/bus/get/error/invalid-user", BusFixture, NULL,
               bus_set_up, test_app_filter_bus_get_error_invalid_user, bus_tear_down);

--- a/libmalcontent/tests/meson.build
+++ b/libmalcontent/tests/meson.build
@@ -16,7 +16,7 @@ gdbus_codegen = find_program('gdbus-codegen')
 
 accounts_service_iface_h = custom_target(
   'accounts-service-iface.h',
-  input: ['org.freedesktop.Accounts.xml'],
+  input: ['org.freedesktop.Accounts.xml', 'org.freedesktop.Accounts.User.xml'],
   output: ['accounts-service-iface.h'],
   command: [gdbus_codegen,
             '--interface-info-header',
@@ -25,7 +25,7 @@ accounts_service_iface_h = custom_target(
 )
 accounts_service_iface_c = custom_target(
   'accounts-service-iface.c',
-  input: ['org.freedesktop.Accounts.xml'],
+  input: ['org.freedesktop.Accounts.xml', 'org.freedesktop.Accounts.User.xml'],
   output: ['accounts-service-iface.c'],
   command: [gdbus_codegen,
             '--interface-info-body',

--- a/libmalcontent/tests/org.freedesktop.Accounts.User.xml
+++ b/libmalcontent/tests/org.freedesktop.Accounts.User.xml
@@ -1,0 +1,939 @@
+<!DOCTYPE node PUBLIC
+"-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd" >
+<node name="/" xmlns:doc="http://www.freedesktop.org/dbus/1.0/doc.dtd">
+  <interface name="org.freedesktop.Accounts.User">
+
+  <method name="SetUserName">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="name" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new username.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users username. Note that it is usually not allowed
+          to have multiple users with the same username.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the username of any user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetRealName">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="name" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new name, typically in the form "Firstname Lastname".
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users real name.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own name</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the name of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetEmail">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="email" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new email address.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users email address.
+        </doc:para>
+        <doc:para>
+          Note that setting an email address in the AccountsService is
+          not the same as configuring a mail client. Mail clients might
+          default to email address that is configured here, though.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own email address</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the email address of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetLanguage">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="language" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new language, as a locale specification like "de_DE.UTF-8".
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users language.
+        </doc:para>
+        <doc:para>
+          The expectation is that display managers will start the
+          users session with this locale.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own language</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the language of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetXSession">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <annotation name="org.freedesktop.DBus.GLib.CSymbol" value="user_set_x_session"/>
+    <arg name="x_session" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new xsession to start (e.g. "gnome")
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users x session.
+        </doc:para>
+        <doc:para>
+          The expectation is that display managers will log the user in to this
+          specified session, if available.
+
+          Note this call is deprecated and has been superceded by SetSession since
+          not all graphical sessions use X as the display server.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own language</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the language of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+   </doc:doc>
+  </method>
+
+  <method name="SetSession">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <annotation name="org.freedesktop.DBus.GLib.CSymbol" value="user_set_session"/>
+    <arg name="session" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new session to start (e.g. "gnome-xorg")
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users wayland or x session.
+        </doc:para>
+        <doc:para>
+          The expectation is that display managers will log the user in to this
+          specified session, if available.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own language</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the language of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+   </doc:doc>
+  </method>
+
+  <method name="SetSessionType">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <annotation name="org.freedesktop.DBus.GLib.CSymbol" value="user_set_session_type"/>
+    <arg name="session_type" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The type of the new session to start (e.g. "wayland" or "x11")
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the session type of the users session.
+        </doc:para>
+        <doc:para>
+          Display managers may use this property to decide what type of display server to use when
+          loading the session
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own language</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the language of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+   </doc:doc>
+  </method>
+
+  <method name="SetLocation">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="location" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new location as a freeform string.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users location.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own location</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the location of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetHomeDirectory">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="homedir" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new homedir as an absolute path.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users home directory.
+        </doc:para>
+        <doc:para>
+          Note that changing the users home directory moves all the content
+          from the old location to the new one, and is potentially an
+          expensive operation.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the home directory of a user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetShell">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="shell" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The new user shell.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users shell.
+        </doc:para>
+        <doc:para>
+          Note that setting the shell to a non-allowed program may
+          prevent the user from logging in.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the shell of a user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetIconFile">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="filename" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The absolute filename of a png file to use as the users icon.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users icon.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own icon</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the icon of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetLocked">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="locked" direction="in" type="b">
+      <doc:doc>
+        <doc:summary>
+          Whether to lock or unlock the users account.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Locks or unlocks a users account.
+        </doc:para>
+        <doc:para>
+          Locking an account prevents the user from logging in.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To lock or unlock user accounts</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetAccountType">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="accountType" direction="in" type="i">
+      <doc:doc>
+        <doc:summary>
+          The new account type, encoded as an integer:
+          <doc:list>
+            <doc:item>
+              <doc:term>0</doc:term>
+              <doc:definition>Standard user</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>1</doc:term>
+              <doc:definition>Administrator</doc:definition>
+            </doc:item>
+          </doc:list>
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Changes the users account type.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change an account type</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetPasswordMode">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="mode" direction="in" type="i">
+      <doc:doc>
+        <doc:summary>
+          The new password mode, encoded as an integer:
+          <doc:list>
+            <doc:item>
+              <doc:term>0</doc:term>
+              <doc:definition>Regular password</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>1</doc:term>
+              <doc:definition>Password must be set at next login</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>2</doc:term>
+              <doc:definition>No password</doc:definition>
+            </doc:item>
+          </doc:list>
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Changes the users password mode.
+        </doc:para>
+        <doc:para>
+          Note that changing the password mode has the side-effect of
+          unlocking the account.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change a users password mode</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetPassword">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="password" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The crypted password.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <arg name="hint" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The password hint.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets a new password for this user.
+        </doc:para>
+        <doc:para>
+          Note that setting a password has the side-effect of
+          unlocking the account.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the password of a user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetPasswordHint">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="hint" direction="in" type="s">
+      <doc:doc>
+        <doc:summary>
+          The password hint.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Sets the users password hint.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.change-own-user-data</doc:term>
+            <doc:definition>To change his own language</doc:definition>
+          </doc:item>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.user-administration</doc:term>
+            <doc:definition>To change the language of another user</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="SetAutomaticLogin">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="enabled" direction="in" type="b">
+      <doc:doc>
+        <doc:summary>
+          Whether to enable automatic login for this user.
+        </doc:summary>
+      </doc:doc>
+    </arg>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Enables or disables automatic login for a user.
+        </doc:para>
+        <doc:para>
+          Note that usually only one user can have automatic login
+          enabled, so turning it on for a user will disable it for
+          the previously configured autologin user.
+        </doc:para>
+      </doc:description>
+      <doc:permission>
+        The caller needs one of the following PolicyKit authorizations:
+        <doc:list>
+          <doc:item>
+            <doc:term>org.freedesktop.accounts.set-login-option</doc:term>
+            <doc:definition>To change the login screen configuration</doc:definition>
+          </doc:item>
+        </doc:list>
+      </doc:permission>
+      <doc:errors>
+        <doc:error name="org.freedesktop.Accounts.Error.PermissionDenied">if the caller lacks the appropriate PolicyKit authorization</doc:error>
+        <doc:error name="org.freedesktop.Accounts.Error.Failed">if the operation failed</doc:error>
+      </doc:errors>
+    </doc:doc>
+  </method>
+
+  <method name="GetPasswordExpirationPolicy">
+    <annotation name="org.freedesktop.DBus.GLib.Async" value=""/>
+    <arg name="expiration_time" direction="out" type="x"/>
+    <arg name="last_change_time" direction="out" type="x"/>
+    <arg name="min_days_between_changes" direction="out" type="x"/>
+    <arg name="max_days_between_changes" direction="out" type="x"/>
+    <arg name="days_to_warn" direction="out" type="x"/>
+    <arg name="days_after_expiration_until_lock" direction="out" type="x"/>
+  </method>
+
+  <property name="Uid" type="t" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The uid of the user.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="UserName" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The username of the user.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="RealName" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users real name.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="AccountType" type="i" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users account type, encoded as an integer:
+          <doc:list>
+            <doc:item>
+              <doc:term>0</doc:term>
+              <doc:definition>Standard user</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>1</doc:term>
+              <doc:definition>Administrator</doc:definition>
+            </doc:item>
+          </doc:list>
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="HomeDirectory" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users home directory.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Shell" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users shell.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Email" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The email address.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Language" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users language, as a locale specification like "de_DE.UTF-8".
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Session" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users Wayland or X session.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="SessionType" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The type of session the user should use (e.g. "wayland" or "x11")
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="XSession" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users x session.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Location" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The users location.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="LoginFrequency" type="t" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          How often the user has logged in.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="LoginTime" type="x" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The last login time.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="LoginHistory" type="a(xxa{sv})" access="read">
+    <annotation name="org.freedesktop.DBus.Property.EmitsChangedSignal" value="false"/>
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The login history for this user.
+          Each entry in the array represents a login session. The first two
+          members are the login time and logout time, as timestamps (seconds since the epoch). If the session is still running, the logout time
+          is 0.
+        </doc:para>
+        <doc:para>
+          The a{sv} member is a dictionary containing additional information
+          about the session. Possible members include 'type' (with values like ':0', 'tty0', 'pts/0' etc).
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="IconFile" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           The filename of a png file containing the users icon.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Saved" type="b" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           Whether the users account has retained state
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="Locked" type="b" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           Whether the users account is locked.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="PasswordMode" type="i" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          The password mode for the user account, encoded as an integer:
+          <doc:list>
+            <doc:item>
+              <doc:term>0</doc:term>
+              <doc:definition>Regular password</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>1</doc:term>
+              <doc:definition>Password must be set at next login</doc:definition>
+            </doc:item>
+            <doc:item>
+              <doc:term>2</doc:term>
+              <doc:definition>No password</doc:definition>
+            </doc:item>
+          </doc:list>
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="PasswordHint" type="s" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           The password hint for the user.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="AutomaticLogin" type="b" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           Whether automatic login is enabled for the user.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="SystemAccount" type="b" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           Whether this is a 'system' account, like 'root' or 'nobody'.
+           System accounts should normally not appear in lists of
+           users, and ListCachedUsers will not include such accounts.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <property name="LocalAccount" type="b" access="read">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+          Whether the user is a local account or not.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </property>
+
+  <signal name="Changed">
+    <doc:doc>
+      <doc:description>
+        <doc:para>
+           Emitted when the user is changed.
+        </doc:para>
+      </doc:description>
+    </doc:doc>
+  </signal>
+
+  </interface>
+</node>

--- a/malcontent-control/application.c
+++ b/malcontent-control/application.c
@@ -102,6 +102,7 @@ mct_application_constructed (GObject *object)
         N_("User to select in the UI"),
         /* Translators: This is a placeholder for a command line argument value: */
         N_("USERNAME") },
+      { NULL, },
     };
 
   g_application_set_application_id (application, "org.freedesktop.MalcontentControl");

--- a/malcontent-control/application.c
+++ b/malcontent-control/application.c
@@ -22,6 +22,7 @@
 #include "config.h"
 
 #include <act/act.h>
+#include <eosmetrics/eosmetrics.h>
 #include <glib.h>
 #include <glib-object.h>
 #include <glib/gi18n-lib.h>
@@ -279,6 +280,86 @@ mct_application_command_line (GApplication            *application,
 }
 
 static void
+mct_application_shutdown (GApplication *application)
+{
+  MctApplication *self = MCT_APPLICATION (application);
+  EmtrEventRecorder *recorder;
+  g_autoptr(MctManager) mct_manager = NULL;
+  g_autoptr(GSList) users = NULL;  /* (element-type ActUser) */
+
+  /* Endless-specific code to send metrics containing all the parental controls
+   * for all users, so we can see how different parental controls features are
+   * being used.
+   *
+   * Serialise the app filter for each user. It’s OK to use blocking calls here,
+   * as the UI is no longer shown.
+   *
+   * See https://phabricator.endlessm.com/T28741#810046 */
+#define MCT_PARENTAL_CONTROLS_EVENT "449ec188-cb7b-45d3-a0ed-291d943b9aa6"
+
+  g_debug ("Gathering parental controls statistics");
+
+  users = act_user_manager_list_users (self->user_manager);
+  mct_manager = mct_manager_new (self->dbus_connection);
+  recorder = emtr_event_recorder_get_default ();
+
+  for (GSList *l = users; l != NULL; l = l->next)
+    {
+      ActUser *user = ACT_USER (l->data);
+      g_autoptr(MctAppFilter) filter = NULL;
+      g_autoptr(GError) local_error = NULL;
+      g_autoptr(GVariant) serialised_filter = NULL;
+      gboolean is_administrator;
+      g_auto(GVariantDict) dict = G_VARIANT_DICT_INIT (NULL);
+
+      /* Skip system accounts. */
+      if (act_user_is_system_account (user))
+        continue;
+
+      /* Get the user’s filter. */
+      filter = mct_manager_get_app_filter (mct_manager,
+                                           act_user_get_uid (user),
+                                           MCT_MANAGER_GET_VALUE_FLAGS_NONE,
+                                           NULL,
+                                           &local_error);
+      if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_DISABLED))
+        {
+          g_debug ("Skipping metrics submission as parental controls are globally disabled");
+          break;
+        }
+      else if (g_error_matches (local_error, MCT_MANAGER_ERROR, MCT_MANAGER_ERROR_PERMISSION_DENIED))
+        {
+          g_debug ("Failed to get app filter for metrics for user %u: %s",
+                   (guint) act_user_get_uid (user), local_error->message);
+          continue;
+        }
+      else if (local_error != NULL)
+        {
+          g_warning ("Failed to get app filter for metrics for user %u: %s",
+                     (guint) act_user_get_uid (user), local_error->message);
+          continue;
+        }
+
+      serialised_filter = mct_app_filter_serialize (filter);
+
+      /* Add an additional `IsAdministrator` key to help the stats. */
+      is_administrator = (act_user_get_account_type (user) == ACT_USER_ACCOUNT_TYPE_ADMINISTRATOR);
+
+      g_variant_dict_init (&dict, serialised_filter);
+      g_variant_dict_insert (&dict, "IsAdministrator", "b", is_administrator);
+      g_variant_dict_insert (&dict, "IsInitialSetup", "b", FALSE);
+
+      /* Send the metrics for this user. */
+      emtr_event_recorder_record_event (recorder,
+                                        MCT_PARENTAL_CONTROLS_EVENT,
+                                        g_variant_dict_end (&dict));
+    }
+
+  /* Chain up. */
+  G_APPLICATION_CLASS (mct_application_parent_class)->shutdown (application);
+}
+
+static void
 mct_application_class_init (MctApplicationClass *klass)
 {
   GObjectClass *object_class = G_OBJECT_CLASS (klass);
@@ -290,6 +371,7 @@ mct_application_class_init (MctApplicationClass *klass)
   application_class->activate = mct_application_activate;
   application_class->startup = mct_application_startup;
   application_class->command_line = mct_application_command_line;
+  application_class->shutdown = mct_application_shutdown;
 }
 
 static void

--- a/malcontent-control/application.c
+++ b/malcontent-control/application.c
@@ -414,7 +414,7 @@ update_main_stack (MctApplication *self)
       mct_user_controls_set_user (self->user_controls, selected_user);
 
       new_page_name = "controls";
-      new_focus_widget = GTK_WIDGET (self->user_selector);
+      new_focus_widget = GTK_WIDGET (self->user_controls);
     }
   else
     {
@@ -426,7 +426,12 @@ update_main_stack (MctApplication *self)
   gtk_stack_set_visible_child_name (self->main_stack, new_page_name);
 
   if (new_focus_widget != NULL && !g_str_equal (old_page_name, new_page_name))
-    gtk_widget_grab_focus (new_focus_widget);
+    {
+      if (gtk_widget_get_can_focus (new_focus_widget))
+        gtk_widget_grab_focus (new_focus_widget);
+      else
+        gtk_widget_child_focus (new_focus_widget, GTK_DIR_TAB_FORWARD);
+    }
 }
 
 static void

--- a/malcontent-control/meson.build
+++ b/malcontent-control/meson.build
@@ -24,6 +24,7 @@ malcontent_control = executable('malcontent-control',
   ] + resources,
   dependencies: [
     dependency('accountsservice'),
+    dependency('eosmetrics-0', version: '>= 0.5.0'),
     dependency('gio-2.0', version: '>= 2.44'),
     dependency('glib-2.0', version: '>= 2.54.2'),
     dependency('gobject-2.0', version: '>= 2.54'),

--- a/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
@@ -43,6 +43,15 @@
   </kudos>
   <translation type="gettext">malcontent</translation>
   <releases>
+    <release version="0.10.1" date="2021-03-11" type="stable">
+      <description>
+        <p>This is a stable release with the following changes:</p>
+        <ul>
+          <li>Sort apps by displayed name when listing them</li>
+          <li>Translation updates</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.10.0" date="2020-12-09" type="stable">
       <description>
         <p>This is a stable release with the following changes:</p>

--- a/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
@@ -43,6 +43,15 @@
   </kudos>
   <translation type="gettext">malcontent</translation>
   <releases>
+    <release version="0.10.2" date="2021-09-17" type="stable">
+      <description>
+        <p>This is a stable release with the following changes:</p>
+        <ul>
+          <li>Hide the launcher for malcontent-control from gnome-shell if using the GNOME desktop; find it via gnome-control-center instead</li>
+          <li>Translation updates</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.10.1" date="2021-03-11" type="stable">
       <description>
         <p>This is a stable release with the following changes:</p>

--- a/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
@@ -21,7 +21,7 @@
   </description>
   <screenshots>
     <screenshot height="552" width="699" type="default">
-      <image>https://gitlab.freedesktop.org/pwithnall/malcontent/-/raw/master/malcontent-control/malcontent-control.png</image>
+      <image>https://gitlab.freedesktop.org/pwithnall/malcontent/-/raw/HEAD/malcontent-control/malcontent-control.png</image>
       <caption>Main window</caption>
     </screenshot>
   </screenshots>

--- a/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in
@@ -34,6 +34,7 @@
   <url type="donation">http://www.gnome.org/friends/</url>
   <url type="translate">https://wiki.gnome.org/TranslationProject/LocalisationGuide</url>
   <update_contact>philip_at_tecnocode.co.uk</update_contact>
+  <compulsory_for_desktop>GNOME</compulsory_for_desktop>
   <project_group>GNOME</project_group>
   <developer_name>The GNOME Project</developer_name>
   <kudos>

--- a/malcontent-control/org.freedesktop.MalcontentControl.desktop.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.desktop.in
@@ -7,6 +7,7 @@ Icon=org.freedesktop.MalcontentControl
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;System;
+NotShowIn=GNOME;
 StartupNotify=true
 # Translators: Search terms to find this application. Do NOT translate or localise the semicolons! The list MUST also end with a semicolon!
 Keywords=parental controls;screen time;app restrictions;web browser restrictions;oars;usage;usage limit;kid;child;

--- a/malcontent-control/org.freedesktop.MalcontentControl.desktop.in
+++ b/malcontent-control/org.freedesktop.MalcontentControl.desktop.in
@@ -7,7 +7,6 @@ Icon=org.freedesktop.MalcontentControl
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;System;
-NotShowIn=GNOME;
 StartupNotify=true
 # Translators: Search terms to find this application. Do NOT translate or localise the semicolons! The list MUST also end with a semicolon!
 Keywords=parental controls;screen time;app restrictions;web browser restrictions;oars;usage;usage limit;kid;child;

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('malcontent', 'c',
-  version : '0.10.0',
+  version : '0.10.1',
   meson_version : '>= 0.50.0',
   license: ['LGPL-2.1-or-later', 'GPL-2.0-or-later'],
   default_options : [

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('malcontent', 'c',
-  version : '0.11.0',
+  version : '0.10.2',
   meson_version : '>= 0.50.0',
   license: ['LGPL-2.1-or-later', 'GPL-2.0-or-later'],
   default_options : [

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('malcontent', 'c',
-  version : '0.10.1',
+  version : '0.11.0',
   meson_version : '>= 0.50.0',
   license: ['LGPL-2.1-or-later', 'GPL-2.0-or-later'],
   default_options : [

--- a/po/cs.po
+++ b/po/cs.po
@@ -6,16 +6,18 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-10 12:04+0100\n"
-"PO-Revision-Date: 2020-04-15 13:42+0100\n"
-"Last-Translator: Automatically generated\n"
+"Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
+"issues\n"
+"POT-Creation-Date: 2021-09-18 12:41+0000\n"
+"PO-Revision-Date: 2021-10-01 00:24+0200\n"
+"Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: none\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"X-Generator: Poedit 3.0\n"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:4
 msgid "Change your own app filter"
@@ -123,9 +125,10 @@ msgstr ""
 msgid "OARS filter for user %u has an unrecognized kind ‘%s’"
 msgstr ""
 
-#: libmalcontent/manager.c:283 libmalcontent/manager.c:412
+#: libmalcontent/manager.c:283 libmalcontent/manager.c:420
+#: libmalcontent/manager.c:803
 #, c-format
-msgid "Not allowed to query app filter data for user %u"
+msgid "Not allowed to query parental controls data for user %u"
 msgstr ""
 
 #: libmalcontent/manager.c:288
@@ -133,17 +136,16 @@ msgstr ""
 msgid "User %u does not exist"
 msgstr ""
 
-#: libmalcontent/manager.c:394
+#: libmalcontent/manager.c:296
+msgid "System accounts service not available"
+msgstr ""
+
+#: libmalcontent/manager.c:402
 msgid "App filtering is globally disabled"
 msgstr ""
 
-#: libmalcontent/manager.c:777
+#: libmalcontent/manager.c:785
 msgid "Session limits are globally disabled"
-msgstr ""
-
-#: libmalcontent/manager.c:795
-#, c-format
-msgid "Not allowed to query session limits data for user %u"
 msgstr ""
 
 #: libmalcontent/session-limits.c:306
@@ -222,17 +224,17 @@ msgid "No applications found to restrict."
 msgstr ""
 
 #. Translators: this is the full name for an unknown user account.
-#: libmalcontent-ui/user-controls.c:242 libmalcontent-ui/user-controls.c:253
+#: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.c:338 libmalcontent-ui/user-controls.c:425
-#: libmalcontent-ui/user-controls.c:711
+#: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
+#: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
 msgstr ""
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:514
+#: libmalcontent-ui/user-controls.c:477
 #, c-format
 msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
@@ -240,92 +242,113 @@ msgid ""
 msgstr ""
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:519
+#: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
 msgstr ""
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:524
+#: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
 msgstr ""
 
-#. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:529
-#, c-format
-msgid "Applications installed by %s will not appear for other users."
-msgstr ""
-
-#: libmalcontent-ui/user-controls.ui:17
+#: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:68
+#: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:152
+#: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:231
+#: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:281
+#: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:366
-msgid "Restrict Application Installation for _Others"
-msgstr ""
-
-#: libmalcontent-ui/user-controls.ui:451
+#: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
 msgstr ""
 
-#: libmalcontent-ui/user-controls.ui:473
+#: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
 msgstr ""
 
+#. Translators: This documents the --user command line option to malcontent-control:
+#: malcontent-control/application.c:102
+msgid "User to select in the UI"
+msgstr ""
+
+#. Translators: This is a placeholder for a command line argument value:
+#: malcontent-control/application.c:104
+msgid "USERNAME"
+msgstr ""
+
+#: malcontent-control/application.c:115
+msgid "— view and edit parental controls"
+msgstr ""
+
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
-#: malcontent-control/application.c:105 malcontent-control/main.ui:12
+#: malcontent-control/application.c:122 malcontent-control/main.ui:12
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:9
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:3
 msgid "Parental Controls"
-msgstr ""
+msgstr "Rodičovská kontrola"
 
-#: malcontent-control/application.c:270
+#: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
 msgstr ""
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
-#: malcontent-control/application.c:275
+#: malcontent-control/application.c:313
 msgid "translator-credits"
 msgstr ""
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
-#: malcontent-control/application.c:281
+#: malcontent-control/application.c:319
 msgid "Malcontent Website"
 msgstr ""
 
-#: malcontent-control/application.c:299
+#: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
 msgstr ""
 
-#: malcontent-control/application.c:336
+#: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
 msgstr ""
 
-#: malcontent-control/application.c:338
+#: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
+msgstr ""
+
+#. Translators: Replace the link to commonsensemedia.org with some
+#. * localised guidance for parents/carers on how to set restrictions on
+#. * their child/caree in a responsible way which is in keeping with the
+#. * best practice and culture of the region. If no suitable localised
+#. * guidance exists, and if the default commonsensemedia.org link is not
+#. * suitable, please file an issue against malcontent so we can discuss
+#. * further!
+#. * https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/new
+#.
+#: malcontent-control/application.c:407
+#, c-format
+msgid ""
+"It’s recommended that restrictions are set as part of an ongoing "
+"conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Read guidance</a> on what to consider."
 msgstr ""
 
 #: malcontent-control/carousel.ui:48
@@ -336,40 +359,40 @@ msgstr ""
 msgid "Next Page"
 msgstr ""
 
-#: malcontent-control/main.ui:93
+#: malcontent-control/main.ui:115
 msgid "Permission Required"
 msgstr ""
 
-#: malcontent-control/main.ui:107
+#: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
 
-#: malcontent-control/main.ui:148
-msgid "No Child Users Configured"
+#: malcontent-control/main.ui:184
+msgid "No Standard User Accounts"
 msgstr ""
 
-#: malcontent-control/main.ui:162
+#: malcontent-control/main.ui:199
 msgid ""
-"No child users are currently set up on the system. Create one before setting "
-"up their parental controls."
+"Parental controls can only be applied to standard user\n"
+"accounts. These can be created in the user settings."
 msgstr ""
 
-#: malcontent-control/main.ui:174
-msgid "Create _Child User"
+#: malcontent-control/main.ui:212
+msgid "_User Settings"
 msgstr ""
 
-#: malcontent-control/main.ui:202
+#: malcontent-control/main.ui:242
 msgid "Loading…"
 msgstr ""
 
-#: malcontent-control/main.ui:265
+#: malcontent-control/main.ui:305
 msgid "_Help"
 msgstr "_Nápověda"
 
-#: malcontent-control/main.ui:269
+#: malcontent-control/main.ui:309
 msgid "_About Parental Controls"
-msgstr ""
+msgstr "O _aplikaci Rodičovská kontrola"
 
 #. Translators: the brief summary of the application as it appears in a software center.
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:12
@@ -385,54 +408,16 @@ msgid ""
 "software they can run."
 msgstr ""
 
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:39
+#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:25
+msgid "Main window"
+msgstr ""
+
+#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:38
 msgid "The GNOME Project"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:50
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:59
-msgid "Minor improvements to parental controls application UI"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:51
-msgid "Add a user manual"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:52
-msgid "Translation updates"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:60
-msgid "Translations to Ukrainian and Polish"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:67
-msgid "Improve parental controls application UI and add icon"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:68
-msgid "Support for indicating which accounts are parent accounts"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:75
-msgid "Initial release of basic parental controls application"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:76
-msgid "Support for setting app installation and run restrictions on users"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:83
-msgid "Maintenance release of underlying parental controls library"
-msgstr ""
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:7
-msgid "org.freedesktop.MalcontentControl"
-msgstr ""
+msgstr "Projekt GNOME"
 
 #. Translators: Search terms to find this application. Do NOT translate or localise the semicolons! The list MUST also end with a semicolon!
-#: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:13
+#: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:14
 msgid ""
 "parental controls;screen time;app restrictions;web browser restrictions;oars;"
 "usage;usage limit;kid;child;"

--- a/po/cs.po
+++ b/po/cs.po
@@ -9,7 +9,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
 "issues\n"
 "POT-Creation-Date: 2021-09-18 12:41+0000\n"
-"PO-Revision-Date: 2021-10-01 00:24+0200\n"
+"PO-Revision-Date: 2021-10-02 00:36+0200\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: none\n"
 "Language: cs\n"
@@ -21,217 +21,218 @@ msgstr ""
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:4
 msgid "Change your own app filter"
-msgstr ""
+msgstr "Měnit filtr vlastních aplikací"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:5
 msgid "Authentication is required to change your app filter."
-msgstr ""
+msgstr "Pro změnu vlastního filtru aplikací je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:14
 msgid "Read your own app filter"
-msgstr ""
+msgstr "Číst filtr vlastních aplikací"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:15
 msgid "Authentication is required to read your app filter."
-msgstr ""
+msgstr "Pro čtení vlastního filtru aplikací je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:24
 msgid "Change another user’s app filter"
-msgstr ""
+msgstr "Měnit filtr aplikací jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:25
 msgid "Authentication is required to change another user’s app filter."
-msgstr ""
+msgstr "Pro změnu filtru aplikací jiného uživatele je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:34
 msgid "Read another user’s app filter"
-msgstr ""
+msgstr "Číst filtr aplikací jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:35
 msgid "Authentication is required to read another user’s app filter."
-msgstr ""
+msgstr "Pro čtení filtru aplikací jiného uživatele je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:44
 msgid "Change your own session limits"
-msgstr ""
+msgstr "Měnit limity vlastního sezení"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:45
 msgid "Authentication is required to change your session limits."
-msgstr ""
+msgstr "Pro změnu limitů vlastního sezení je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:54
 msgid "Read your own session limits"
-msgstr ""
+msgstr "Číst limity vlastního sezení"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:55
 msgid "Authentication is required to read your session limits."
-msgstr ""
+msgstr "Pro čtení limitů vlastního sezení je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:64
 msgid "Change another user’s session limits"
-msgstr ""
+msgstr "Měnit limity sezení jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:65
 msgid "Authentication is required to change another user’s session limits."
-msgstr ""
+msgstr "Pro změnu limitů sezení jiného uživatele je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:74
 msgid "Read another user’s session limits"
-msgstr ""
+msgstr "Číst limity sezení jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:75
 msgid "Authentication is required to read another user’s session limits."
-msgstr ""
+msgstr "Pro čtení limitů sezení jiného uživatele je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:84
 msgid "Change your own account info"
-msgstr ""
+msgstr "Měnit informace o vlastním účtu"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:85
 msgid "Authentication is required to change your account info."
-msgstr ""
+msgstr "Pro změnu informací o vlastním účtu je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:94
 msgid "Read your own account info"
-msgstr ""
+msgstr "Číst informace o vlastním účtu"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:95
 msgid "Authentication is required to read your account info."
-msgstr ""
+msgstr "Pro čtení informací o vlastním účtu je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:104
 msgid "Change another user’s account info"
-msgstr ""
+msgstr "Měnit informace o účtu jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:105
 msgid "Authentication is required to change another user’s account info."
-msgstr ""
+msgstr "Pro změnu informací o účtu jiného uživatele je vyžadováno ověření."
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:114
 msgid "Read another user’s account info"
-msgstr ""
+msgstr "Číst informace o účtu jiného uživatele"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:115
 msgid "Authentication is required to read another user’s account info."
-msgstr ""
+msgstr "Pro čtení informací o účtu jiného uživatele je vyžadováno ověření."
 
 #: libmalcontent/app-filter.c:694
 #, c-format
 msgid "App filter for user %u was in an unrecognized format"
-msgstr ""
+msgstr "Filtr aplikací pro uživatele %u byl v nerozpoznaném formátu"
 
 #: libmalcontent/app-filter.c:725
 #, c-format
 msgid "OARS filter for user %u has an unrecognized kind ‘%s’"
-msgstr ""
+msgstr "OARS filtr pro uživatele %u má nerozpoznaný typ ‘%s’"
 
 #: libmalcontent/manager.c:283 libmalcontent/manager.c:420
 #: libmalcontent/manager.c:803
 #, c-format
 msgid "Not allowed to query parental controls data for user %u"
 msgstr ""
+"Není povoleno dotazovat se na data rodičovské kontroly pro uživatele %u"
 
 #: libmalcontent/manager.c:288
 #, c-format
 msgid "User %u does not exist"
-msgstr ""
+msgstr "Uživatel %u neexistuje"
 
 #: libmalcontent/manager.c:296
 msgid "System accounts service not available"
-msgstr ""
+msgstr "Služba systémových účtů není dostupná"
 
 #: libmalcontent/manager.c:402
 msgid "App filtering is globally disabled"
-msgstr ""
+msgstr "Filtrování aplikací je globálně zakázáno"
 
 #: libmalcontent/manager.c:785
 msgid "Session limits are globally disabled"
-msgstr ""
+msgstr "Limity sezení jsou globálně zakázány"
 
 #: libmalcontent/session-limits.c:306
 #, c-format
 msgid "Session limit for user %u was in an unrecognized format"
-msgstr ""
+msgstr "Limit sezení pro uživatele %u byl v nerozpoznaném formátu"
 
 #: libmalcontent/session-limits.c:328
 #, c-format
 msgid "Session limit for user %u has an unrecognized type ‘%u’"
-msgstr ""
+msgstr "Limit sezení pro uživatele %u má nerozpoznaný typ ‘%u’"
 
 #: libmalcontent/session-limits.c:346
 #, c-format
 msgid "Session limit for user %u has invalid daily schedule %u–%u"
-msgstr ""
+msgstr "Limit sezení pro uživatele %u má neplatný denní rozvrh %u–%u"
 
 #. TRANSLATORS: This is the formatting of English and localized name
 #. of the rating e.g. "Adults Only (solo adultos)"
 #: libmalcontent-ui/gs-content-rating.c:75
 #, c-format
 msgid "%s (%s)"
-msgstr ""
+msgstr "%s (%s)"
 
 #: libmalcontent-ui/gs-content-rating.c:209
 msgid "General"
-msgstr ""
+msgstr "Obecné"
 
 #: libmalcontent-ui/gs-content-rating.c:218
 msgid "ALL"
-msgstr ""
+msgstr "VŠECHNY"
 
 #: libmalcontent-ui/gs-content-rating.c:222
 #: libmalcontent-ui/gs-content-rating.c:485
 msgid "Adults Only"
-msgstr ""
+msgstr "pouze dospělé"
 
 #: libmalcontent-ui/gs-content-rating.c:224
 #: libmalcontent-ui/gs-content-rating.c:484
 msgid "Mature"
-msgstr ""
+msgstr "plnoleté"
 
 #: libmalcontent-ui/gs-content-rating.c:226
 #: libmalcontent-ui/gs-content-rating.c:483
 msgid "Teen"
-msgstr ""
+msgstr "mládež"
 
 #: libmalcontent-ui/gs-content-rating.c:228
 #: libmalcontent-ui/gs-content-rating.c:482
 msgid "Everyone 10+"
-msgstr ""
+msgstr "všechny 10+"
 
 #: libmalcontent-ui/gs-content-rating.c:230
 #: libmalcontent-ui/gs-content-rating.c:481
 msgid "Everyone"
-msgstr ""
+msgstr "všechny"
 
 #: libmalcontent-ui/gs-content-rating.c:232
 #: libmalcontent-ui/gs-content-rating.c:480
 msgid "Early Childhood"
-msgstr ""
+msgstr "malé děti"
 
 #. Translators: the placeholder is a user’s full name
 #: libmalcontent-ui/restrict-applications-dialog.c:222
 #, c-format
 msgid "Restrict %s from using the following installed applications."
-msgstr ""
+msgstr "Omezit uživateli %s použití následujících nainstalovaných aplikací."
 
 #: libmalcontent-ui/restrict-applications-dialog.ui:6
 #: libmalcontent-ui/restrict-applications-dialog.ui:12
 msgid "Restrict Applications"
-msgstr ""
+msgstr "Omezit aplikace"
 
 #: libmalcontent-ui/restrict-applications-selector.ui:24
 msgid "No applications found to restrict."
-msgstr ""
+msgstr "Nenalezeny žádné aplikace k omezení."
 
 #. Translators: this is the full name for an unknown user account.
 #: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
-msgstr ""
+msgstr "neznámé"
 
 #: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
 #: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
-msgstr ""
+msgstr "libovolný věk"
 
 #. Translators: The placeholder is a user’s display name.
 #: libmalcontent-ui/user-controls.c:477
@@ -240,62 +241,66 @@ msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
 "available in other applications."
 msgstr ""
+"Zabraňuje uživateli %s ve spouštění webových prohlížečů. Omezený webový "
+"obsah může být stále dostupný v jiných aplikacích."
 
 #. Translators: The placeholder is a user’s display name.
 #: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
-msgstr ""
+msgstr "Zabraňuje v používání určených aplikací uživatelem %s."
 
 #. Translators: The placeholder is a user’s display name.
 #: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
-msgstr ""
+msgstr "Zabraňuje uživateli %s v instalaci aplikací."
 
 #: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
-msgstr ""
+msgstr "Omezení použití aplikací"
 
 #: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
-msgstr ""
+msgstr "Omezit _webové prohlížeče"
 
 #: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
-msgstr ""
+msgstr "Omezit _aplikace"
 
 #: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
-msgstr ""
+msgstr "Omezení instalace softwaru"
 
 #: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
-msgstr ""
+msgstr "Omezit _instalaci aplikací"
 
 #: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
-msgstr ""
+msgstr "Vhodno_st aplikací"
 
 #: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
 msgstr ""
+"Omezí prohlížení nebo instalaci aplikací na aplikace vhodné pro určitý věk "
+"nebo výše."
 
 #. Translators: This documents the --user command line option to malcontent-control:
 #: malcontent-control/application.c:102
 msgid "User to select in the UI"
-msgstr ""
+msgstr "Uživatel ke zvolení v UI"
 
 #. Translators: This is a placeholder for a command line argument value:
 #: malcontent-control/application.c:104
 msgid "USERNAME"
-msgstr ""
+msgstr "UŽIVATEL"
 
 #: malcontent-control/application.c:115
 msgid "— view and edit parental controls"
-msgstr ""
+msgstr "— zobrazit a upravit rodičovskou kontrolu"
 
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
@@ -307,32 +312,32 @@ msgstr "Rodičovská kontrola"
 
 #: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
-msgstr ""
+msgstr "Copyright © 2019, 2020 Endless Mobile, Inc."
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
 #: malcontent-control/application.c:313
 msgid "translator-credits"
-msgstr ""
+msgstr "Daniel Rusek <mail@asciiwolf.com>"
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
 #: malcontent-control/application.c:319
 msgid "Malcontent Website"
-msgstr ""
+msgstr "Webové stránky"
 
 #: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
-msgstr ""
+msgstr "Obsah nápovědy nemohl být zobrazen"
 
 #: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
-msgstr ""
+msgstr "Selhalo načtení uživatelských dat ze systému"
 
 #: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
-msgstr ""
+msgstr "Ověřte prosím, že je AccountsService nainstalováno a povoleno."
 
 #. Translators: Replace the link to commonsensemedia.org with some
 #. * localised guidance for parents/carers on how to set restrictions on
@@ -350,41 +355,47 @@ msgid ""
 "conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
 "internet-safety'>Read guidance</a> on what to consider."
 msgstr ""
+"Je doporučeno, aby byla omezení nastavena jako součást probíhající "
+"konverzace s %s. <a href='https://www.jaknainternet.cz/page/1201/ochrana-"
+"deti-na-internetu/'>Přečtěte si návod</a> na to, co je třeba vzít v úvahu."
 
 #: malcontent-control/carousel.ui:48
 msgid "Previous Page"
-msgstr ""
+msgstr "Předchozí stránka"
 
 #: malcontent-control/carousel.ui:74
 msgid "Next Page"
-msgstr ""
+msgstr "Následující stránka"
 
 #: malcontent-control/main.ui:115
 msgid "Permission Required"
-msgstr ""
+msgstr "Vyžadováno oprávnění"
 
 #: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
+"Pro zobrazení a změnu rodičovské kontroly uživatele je nutné oprávnění."
 
 #: malcontent-control/main.ui:184
 msgid "No Standard User Accounts"
-msgstr ""
+msgstr "Žádný běžný uživatelský účet"
 
 #: malcontent-control/main.ui:199
 msgid ""
 "Parental controls can only be applied to standard user\n"
 "accounts. These can be created in the user settings."
 msgstr ""
+"Rodičovská kontrola může být aplikována pouze na standardní uživatelské\n"
+"účty. Ty mohou být vytvořeny v nastavení uživatelů."
 
 #: malcontent-control/main.ui:212
 msgid "_User Settings"
-msgstr ""
+msgstr "Nastavení _uživatelů"
 
 #: malcontent-control/main.ui:242
 msgid "Loading…"
-msgstr ""
+msgstr "Načítá se…"
 
 #: malcontent-control/main.ui:305
 msgid "_Help"
@@ -398,7 +409,7 @@ msgstr "O _aplikaci Rodičovská kontrola"
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:12
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:4
 msgid "Set parental controls and monitor usage by users"
-msgstr ""
+msgstr "Nastavte rodičovskou kontrolu a monitorujte používání uživateli"
 
 #. Translators: These are the application description paragraphs in the AppData file.
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:16
@@ -407,10 +418,13 @@ msgid ""
 "use the computer for, what software they can install, and what installed "
 "software they can run."
 msgstr ""
+"Spravujte omezení rodičovské kontroly uživatelů, určující jak dlouho mohou "
+"používat počítač, jaký software mohou instalovat a jaký software mohou "
+"spouštět."
 
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:25
 msgid "Main window"
-msgstr ""
+msgstr "Hlavní okno"
 
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:38
 msgid "The GNOME Project"
@@ -422,14 +436,17 @@ msgid ""
 "parental controls;screen time;app restrictions;web browser restrictions;oars;"
 "usage;usage limit;kid;child;"
 msgstr ""
+"rodičovská kontrola;čas u obrazovky;omezení aplikací;omezení webového "
+"prohlížeče;oars;použití;omezení použití;dítě;děti;"
 
 #: malcontent-control/org.freedesktop.MalcontentControl.policy.in:9
 msgid "Manage parental controls"
-msgstr ""
+msgstr "Spravovat rodičovskou kontrolu"
 
 #: malcontent-control/org.freedesktop.MalcontentControl.policy.in:10
 msgid "Authentication is required to read and change user parental controls"
 msgstr ""
+"Pro zobrazení a změnu rodičovské kontroly uživatele je vyžadováno ověření"
 
 #: malcontent-control/user-selector.c:426
 msgid "Your account"
@@ -440,22 +457,22 @@ msgstr "Váš účet"
 #: pam/pam_malcontent.c:142 pam/pam_malcontent.c:188
 #, c-format
 msgid "User ‘%s’ has no time limits enabled"
-msgstr ""
+msgstr "Uživatel ‘%s’ nemá nastaveny časové limity"
 
 #: pam/pam_malcontent.c:151 pam/pam_malcontent.c:172
 #, c-format
 msgid "Error getting session limits for user ‘%s’: %s"
-msgstr ""
+msgstr "Chyba při získávání limitů sezení pro uživatele ‘%s’: %s"
 
 #: pam/pam_malcontent.c:182
 #, c-format
 msgid "User ‘%s’ has no time remaining"
-msgstr ""
+msgstr "Uživatel ‘%s’ nemá žádný zbývající čas"
 
 #: pam/pam_malcontent.c:200
 #, c-format
 msgid "Error setting time limit on login session: %s"
-msgstr ""
+msgstr "Chyba při nastavení časového limitu na přihlašovací sezení: %s"
 
 #~ msgid "No cartoon violence"
 #~ msgstr "Žádné kreslené násilí"

--- a/po/id.po
+++ b/po/id.po
@@ -1,21 +1,22 @@
 # Indonesian translation for malcontent.
 # Copyright (C) 2020 malcontent's COPYRIGHT HOLDER
 # This file is distributed under the same license as the malcontent package.
-# Andika Triwidada <atriwidada@gnome.org>, 2020.
+# Andika Triwidada <atriwidada@gnome.org>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent master\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-10 12:04+0100\n"
-"PO-Revision-Date: 2020-03-31 19:22+0700\n"
+"Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
+"issues\n"
+"POT-Creation-Date: 2020-12-18 15:14+0000\n"
+"PO-Revision-Date: 2021-08-30 18:21+0700\n"
 "Last-Translator: Andika Triwidada <andika@gmail.com>\n"
 "Language-Team: Indonesian <gnome-l10n-id@googlegroups.com>\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.3\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:4
 msgid "Change your own app filter"
@@ -123,28 +124,29 @@ msgstr "Filter aplikasi untuk pengguna %u dalam format yang tidak dikenal"
 msgid "OARS filter for user %u has an unrecognized kind ‘%s’"
 msgstr "Filter OARS untuk pengguna %u memiliki jenis yang tidak dikenal '%s'"
 
-#: libmalcontent/manager.c:283 libmalcontent/manager.c:412
+#: libmalcontent/manager.c:283 libmalcontent/manager.c:420
+#: libmalcontent/manager.c:803
 #, c-format
-msgid "Not allowed to query app filter data for user %u"
-msgstr "Tidak diizinkan untuk meminta data filter aplikasi untuk pengguna %u"
+msgid "Not allowed to query parental controls data for user %u"
+msgstr ""
+"Tidak diizinkan untuk menanyakan data pengawasan orang tua untuk pengguna %u"
 
 #: libmalcontent/manager.c:288
 #, c-format
 msgid "User %u does not exist"
 msgstr "Pengguna %u tidak ada"
 
-#: libmalcontent/manager.c:394
+#: libmalcontent/manager.c:296
+msgid "System accounts service not available"
+msgstr "Layanan akun sistem tidak tersedia"
+
+#: libmalcontent/manager.c:402
 msgid "App filtering is globally disabled"
 msgstr "Penyaringan aplikasi dinonaktifkan secara global"
 
-#: libmalcontent/manager.c:777
+#: libmalcontent/manager.c:785
 msgid "Session limits are globally disabled"
 msgstr "Batas sesi dinonaktifkan secara global"
-
-#: libmalcontent/manager.c:795
-#, c-format
-msgid "Not allowed to query session limits data for user %u"
-msgstr "Tidak diizinkan untuk meminta data batasan sesi untuk pengguna %u"
 
 #: libmalcontent/session-limits.c:306
 #, c-format
@@ -167,45 +169,45 @@ msgstr ""
 #: libmalcontent-ui/gs-content-rating.c:75
 #, c-format
 msgid "%s (%s)"
-msgstr ""
+msgstr "%s (%s)"
 
 #: libmalcontent-ui/gs-content-rating.c:209
 msgid "General"
-msgstr ""
+msgstr "Umum"
 
 #: libmalcontent-ui/gs-content-rating.c:218
 msgid "ALL"
-msgstr ""
+msgstr "SEMUA"
 
 #: libmalcontent-ui/gs-content-rating.c:222
 #: libmalcontent-ui/gs-content-rating.c:485
 msgid "Adults Only"
-msgstr ""
+msgstr "Hanya Orang Dewasa"
 
 #: libmalcontent-ui/gs-content-rating.c:224
 #: libmalcontent-ui/gs-content-rating.c:484
 msgid "Mature"
-msgstr ""
+msgstr "Dewasa"
 
 #: libmalcontent-ui/gs-content-rating.c:226
 #: libmalcontent-ui/gs-content-rating.c:483
 msgid "Teen"
-msgstr ""
+msgstr "Remaja"
 
 #: libmalcontent-ui/gs-content-rating.c:228
 #: libmalcontent-ui/gs-content-rating.c:482
 msgid "Everyone 10+"
-msgstr ""
+msgstr "Siapa Pun 10+"
 
 #: libmalcontent-ui/gs-content-rating.c:230
 #: libmalcontent-ui/gs-content-rating.c:481
 msgid "Everyone"
-msgstr ""
+msgstr "Siapa Pun"
 
 #: libmalcontent-ui/gs-content-rating.c:232
 #: libmalcontent-ui/gs-content-rating.c:480
 msgid "Early Childhood"
-msgstr ""
+msgstr "Anak Usia Dini"
 
 #. Translators: the placeholder is a user’s full name
 #: libmalcontent-ui/restrict-applications-dialog.c:222
@@ -223,17 +225,17 @@ msgid "No applications found to restrict."
 msgstr "Tidak ditemukan aplikasi yang akan dibatasi."
 
 #. Translators: this is the full name for an unknown user account.
-#: libmalcontent-ui/user-controls.c:242 libmalcontent-ui/user-controls.c:253
+#: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
 msgstr "tidak dikenal"
 
-#: libmalcontent-ui/user-controls.c:338 libmalcontent-ui/user-controls.c:425
-#: libmalcontent-ui/user-controls.c:711
+#: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
+#: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
 msgstr "Semua umur"
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:514
+#: libmalcontent-ui/user-controls.c:477
 #, c-format
 msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
@@ -243,52 +245,42 @@ msgstr ""
 "tersedia di aplikasi lain."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:519
+#: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
 msgstr "Mencegah aplikasi tertentu agar tidak digunakan oleh %s."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:524
+#: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
 msgstr "Mencegah %s menginstal aplikasi."
 
-#. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:529
-#, c-format
-msgid "Applications installed by %s will not appear for other users."
-msgstr "Aplikasi yang dipasang oleh %s tidak akan muncul untuk pengguna lain."
-
-#: libmalcontent-ui/user-controls.ui:17
+#: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
 msgstr "Pembatasan Penggunaan Aplikasi"
 
-#: libmalcontent-ui/user-controls.ui:68
+#: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
 msgstr "Batasi Peramban _Web"
 
-#: libmalcontent-ui/user-controls.ui:152
+#: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
 msgstr "_Batasi Aplikasi"
 
-#: libmalcontent-ui/user-controls.ui:231
+#: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
 msgstr "Pembatasan Instalasi Perangkat Lunak"
 
-#: libmalcontent-ui/user-controls.ui:281
+#: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
 msgstr "Batasi _Instalasi Aplikasi"
 
-#: libmalcontent-ui/user-controls.ui:366
-msgid "Restrict Application Installation for _Others"
-msgstr "Batasi Instalasi Aplikasi untuk _Lain"
-
-#: libmalcontent-ui/user-controls.ui:451
+#: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
 msgstr "Ke_sesuaian Aplikasi"
 
-#: libmalcontent-ui/user-controls.ui:473
+#: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
@@ -296,42 +288,77 @@ msgstr ""
 "Membatasi penjelajahan atau pemasangan aplikasi ke aplikasi yang sesuai "
 "untuk usia tertentu atau di atas."
 
+#. Translators: This documents the --user command line option to malcontent-control:
+#: malcontent-control/application.c:102
+msgid "User to select in the UI"
+msgstr "Pengguna yang dipilih dalam UI"
+
+#. Translators: This is a placeholder for a command line argument value:
+#: malcontent-control/application.c:104
+msgid "USERNAME"
+msgstr "NAMAPENGGUNA"
+
+#: malcontent-control/application.c:115
+msgid "— view and edit parental controls"
+msgstr "— tilik dan kelola pengawasan orang tua"
+
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
-#: malcontent-control/application.c:105 malcontent-control/main.ui:12
+#: malcontent-control/application.c:122 malcontent-control/main.ui:12
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:9
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:3
 msgid "Parental Controls"
 msgstr "Pengawasan Orang Tua"
 
-#: malcontent-control/application.c:270
+#: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
-msgstr ""
+msgstr "Hak cipta © 2019, 2020 Endless Mobile, Inc."
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
-#: malcontent-control/application.c:275
+#: malcontent-control/application.c:313
 msgid "translator-credits"
-msgstr ""
+msgstr "Andika Triwidada <andika@gmail.com>, 2020, 2021."
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
-#: malcontent-control/application.c:281
+#: malcontent-control/application.c:319
 msgid "Malcontent Website"
-msgstr ""
+msgstr "Situs Web Malcontent"
 
-#: malcontent-control/application.c:299
+#: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
-msgstr ""
+msgstr "Isi bantuan tidak dapat ditampilkan"
 
-#: malcontent-control/application.c:336
+#: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
 msgstr "Gagal memuat data pengguna dari sistem"
 
-#: malcontent-control/application.c:338
+#: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
 msgstr "Harap pastikan bahwa AccountsService diinstal dan diaktifkan."
+
+#. Translators: Replace the link to commonsensemedia.org with some
+#. * localised guidance for parents/carers on how to set restrictions on
+#. * their child/caree in a responsible way which is in keeping with the
+#. * best practice and culture of the region. If no suitable localised
+#. * guidance exists, and if the default commonsensemedia.org link is not
+#. * suitable, please file an issue against malcontent so we can discuss
+#. * further!
+#. * https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/new
+#.
+#: malcontent-control/application.c:407
+#, c-format
+msgid ""
+"It’s recommended that restrictions are set as part of an ongoing "
+"conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Read guidance</a> on what to consider."
+msgstr ""
+"Disarankan agar pembatasan ditetapkan sebagai bagian dari percakapan yang "
+"sedang berlangsung dengan %s. <a href='https://www.commonsensemedia.org/"
+"privacy-and-internet-safety'>Baca panduan</a> tentang apa yang harus "
+"dipertimbangkan."
 
 #: malcontent-control/carousel.ui:48
 msgid "Previous Page"
@@ -341,45 +368,44 @@ msgstr "Halaman Sebelumnya"
 msgid "Next Page"
 msgstr "Halaman Selanjutnya"
 
-#: malcontent-control/main.ui:93
+#: malcontent-control/main.ui:115
 msgid "Permission Required"
 msgstr "Diperlukan Izin"
 
-#: malcontent-control/main.ui:107
+#: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
 "Diperlukan izin untuk melihat dan mengubah pengaturan kontrol orang tua "
 "pengguna."
 
-#: malcontent-control/main.ui:148
-msgid "No Child Users Configured"
-msgstr "Tidak Ada Pengguna Anak yang Dikonfigurasi"
+#: malcontent-control/main.ui:184
+msgid "No Standard User Accounts"
+msgstr "Tidak Ada Akun Pengguna Standar"
 
-#: malcontent-control/main.ui:162
+#: malcontent-control/main.ui:199
 msgid ""
-"No child users are currently set up on the system. Create one before setting "
-"up their parental controls."
+"Parental controls can only be applied to standard user\n"
+"accounts. These can be created in the user settings."
 msgstr ""
-"Tidak ada pengguna anak yang saat ini diatur pada sistem. Buat satu sebelum "
-"menyiapkan kontrol orangtua mereka."
+"Pengawasan orang tua hanya dapat diterapkan pada akun\n"
+"pengguna standar. Ini dapat dibuat di pengaturan pengguna."
 
-#: malcontent-control/main.ui:174
-msgid "Create _Child User"
-msgstr "Buat Pengguna _Anak"
+#: malcontent-control/main.ui:212
+msgid "_User Settings"
+msgstr "Pengat_uran Pengguna"
 
-#: malcontent-control/main.ui:202
+#: malcontent-control/main.ui:242
 msgid "Loading…"
 msgstr "Memuat…"
 
-#: malcontent-control/main.ui:265
+#: malcontent-control/main.ui:305
 msgid "_Help"
-msgstr ""
+msgstr "Ba_ntuan"
 
-#: malcontent-control/main.ui:269
-#, fuzzy
+#: malcontent-control/main.ui:309
 msgid "_About Parental Controls"
-msgstr "Pengawasan Orang Tua"
+msgstr "Tent_ang Pengawasan Orang Tua"
 
 #. Translators: the brief summary of the application as it appears in a software center.
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:12
@@ -398,51 +424,13 @@ msgstr ""
 "dapat menggunakan komputer, perangkat lunak apa yang dapat mereka instal, "
 "dan perangkat lunak terinstal mana yang dapat mereka jalankan."
 
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:39
+#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:25
+msgid "Main window"
+msgstr "Jendela utama"
+
+#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:38
 msgid "The GNOME Project"
 msgstr "Projek GNOME"
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:50
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:59
-msgid "Minor improvements to parental controls application UI"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:51
-msgid "Add a user manual"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:52
-msgid "Translation updates"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:60
-msgid "Translations to Ukrainian and Polish"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:67
-msgid "Improve parental controls application UI and add icon"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:68
-msgid "Support for indicating which accounts are parent accounts"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:75
-msgid "Initial release of basic parental controls application"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:76
-msgid "Support for setting app installation and run restrictions on users"
-msgstr ""
-
-#: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:83
-msgid "Maintenance release of underlying parental controls library"
-msgstr ""
-
-#. Translators: Do NOT translate or transliterate this text (this is an icon file name)!
-#: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:7
-msgid "org.freedesktop.MalcontentControl"
-msgstr ""
 
 #. Translators: Search terms to find this application. Do NOT translate or localise the semicolons! The list MUST also end with a semicolon!
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:13
@@ -487,303 +475,3 @@ msgstr "Pengguna '%s' tidak punya waktu tersisa"
 #, c-format
 msgid "Error setting time limit on login session: %s"
 msgstr "Kesalahan pengaturan batas waktu pada sesi login: %s"
-
-#~ msgid "No cartoon violence"
-#~ msgstr "Tidak ada kekerasan kartun"
-
-#~ msgid "Cartoon characters in unsafe situations"
-#~ msgstr "Karakter kartun dalam situasi yang tidak aman"
-
-#~ msgid "Cartoon characters in aggressive conflict"
-#~ msgstr "Karakter kartun dalam konflik agresif"
-
-#~ msgid "Graphic violence involving cartoon characters"
-#~ msgstr "Kekerasan grafis yang melibatkan karakter kartun"
-
-#~ msgid "No fantasy violence"
-#~ msgstr "Tidak ada kekerasan fantasi"
-
-#~ msgid "Characters in unsafe situations easily distinguishable from reality"
-#~ msgstr ""
-#~ "Karakter dalam situasi yang tidak aman dengan mudah dibedakan dari "
-#~ "realitas"
-
-#~ msgid ""
-#~ "Characters in aggressive conflict easily distinguishable from reality"
-#~ msgstr "Karakter dalam konflik agresif dengan mudah dibedakan dari realitas"
-
-#~ msgid "Graphic violence easily distinguishable from reality"
-#~ msgstr "Kekerasan grafis dengan mudah dibedakan dari realitas"
-
-#~ msgid "No realistic violence"
-#~ msgstr "Tidak ada kekerasan realistis"
-
-#~ msgid "Mildly realistic characters in unsafe situations"
-#~ msgstr "Sedikit karakter realistis dalam situasi yang tidak aman"
-
-#~ msgid "Depictions of realistic characters in aggressive conflict"
-#~ msgstr "Penggambaran karakter yang realistis dalam konflik agresif"
-
-#~ msgid "Graphic violence involving realistic characters"
-#~ msgstr "Kekerasan grafis yang melibatkan karakter yang realistis"
-
-#~ msgid "No bloodshed"
-#~ msgstr "Tidak ada pertumpahan darah"
-
-#~ msgid "Unrealistic bloodshed"
-#~ msgstr "Pertumpahan darah yang tidak realistis"
-
-#~ msgid "Realistic bloodshed"
-#~ msgstr "Pertumpahan darah yang realistis"
-
-#~ msgid "Depictions of bloodshed and the mutilation of body parts"
-#~ msgstr "Penggambaran pertumpahan darah dan mutilasi bagian tubuh"
-
-#~ msgid "No sexual violence"
-#~ msgstr "Tidak ada kekerasan seksual"
-
-#~ msgid "Rape or other violent sexual behavior"
-#~ msgstr "Perkosaan atau perilaku seksual kekerasan lainnya"
-
-#~ msgid "No references to alcohol"
-#~ msgstr "Tidak ada referensi ke alkohol"
-
-#~ msgid "References to alcoholic beverages"
-#~ msgstr "Referensi ke minuman beralkohol"
-
-#~ msgid "Use of alcoholic beverages"
-#~ msgstr "Penggunaan minuman beralkohol"
-
-#~ msgid "No references to illicit drugs"
-#~ msgstr "Tidak ada referensi untuk obat-obatan terlarang"
-
-#~ msgid "References to illicit drugs"
-#~ msgstr "Referensi untuk obat-obatan terlarang"
-
-#~ msgid "Use of illicit drugs"
-#~ msgstr "Penggunaan obat-obatan terlarang"
-
-#~ msgid "References to tobacco products"
-#~ msgstr "Referensi untuk produk tembakau"
-
-#~ msgid "Use of tobacco products"
-#~ msgstr "Penggunaan produk tembakau"
-
-#~ msgid "No nudity of any sort"
-#~ msgstr "Tidak ada ketelanjangan apapun"
-
-#~ msgid "Brief artistic nudity"
-#~ msgstr "Ketelanjangan artistik singkat"
-
-#~ msgid "Prolonged nudity"
-#~ msgstr "Ketelanjangan berkepanjangan"
-
-#~ msgid "No references or depictions of sexual nature"
-#~ msgstr "Tidak ada referensi atau penggambaran bersifat seksual"
-
-#~ msgid "Provocative references or depictions"
-#~ msgstr "Referensi atau penggambaran provokatif"
-
-#~ msgid "Sexual references or depictions"
-#~ msgstr "Referensi atau penggambaran seksual"
-
-#~ msgid "Graphic sexual behavior"
-#~ msgstr "Perilaku seksual grafis"
-
-#~ msgid "No profanity of any kind"
-#~ msgstr "Tidak ada kata-kata tidak senonoh apapun"
-
-#~ msgid "Mild or infrequent use of profanity"
-#~ msgstr "Penggunaan ringan atau jarang kata-kata tidak senonoh"
-
-#~ msgid "Moderate use of profanity"
-#~ msgstr "Penggunaan sedang kata-kata tidak senonoh"
-
-#~ msgid "Strong or frequent use of profanity"
-#~ msgstr "Penggunaan kuat atau sering kata-kata tidak senonoh"
-
-#~ msgid "No inappropriate humor"
-#~ msgstr "Tidak ada humor yang tidak pantas"
-
-#~ msgid "Slapstick humor"
-#~ msgstr "Humor slapstick"
-
-#~ msgid "Vulgar or bathroom humor"
-#~ msgstr "Humor kamar mandi atau vulgar"
-
-#~ msgid "Mature or sexual humor"
-#~ msgstr "Humor dewasa atau seksual"
-
-#~ msgid "No discriminatory language of any kind"
-#~ msgstr "Tidak ada bahasa diskriminatif apapun"
-
-#~ msgid "Negativity towards a specific group of people"
-#~ msgstr "Negatif terhadap sekelompok orang tertentu"
-
-#~ msgid "Discrimination designed to cause emotional harm"
-#~ msgstr "Diskriminasi dirancang untuk menyebabkan kerusakan emosional"
-
-#~ msgid "Explicit discrimination based on gender, sexuality, race or religion"
-#~ msgstr ""
-#~ "Diskriminasi eksplisit berdasarkan gender, seksualitas, ras, atau agama"
-
-#~ msgid "No advertising of any kind"
-#~ msgstr "Tidak ada iklan jenis apapun"
-
-#~ msgid "Product placement"
-#~ msgstr "Penempatan produk"
-
-#~ msgid "Explicit references to specific brands or trademarked products"
-#~ msgstr ""
-#~ "Referensi eksplisit untuk merek tertentu atau produk dengan merek dagang"
-
-#~ msgid "Users are encouraged to purchase specific real-world items"
-#~ msgstr "Pengguna dianjurkan untuk membeli barang dunia nyata tertentu"
-
-#~ msgid "No gambling of any kind"
-#~ msgstr "Tidak ada perjudian jenis apapun"
-
-#~ msgid "Gambling on random events using tokens or credits"
-#~ msgstr "Perjudian pada peristiwa acak menggunakan token atau kredit"
-
-#~ msgid "Gambling using “play” money"
-#~ msgstr "Perjudian menggunakan uang \"permainan\""
-
-#~ msgid "Gambling using real money"
-#~ msgstr "Perjudian menggunakan uang nyata"
-
-#~ msgid "No ability to spend money"
-#~ msgstr "Tidak ada kemampuan membelanjakan uang"
-
-#~ msgid "Users are encouraged to donate real money"
-#~ msgstr "Pengguna dianjurkan untuk menyumbangkan uang sungguhan"
-
-#~ msgid "Ability to spend real money in-game"
-#~ msgstr "Kemampuan untuk menghabiskan uang nyata dalam permainan"
-
-#~ msgid "No way to chat with other users"
-#~ msgstr "Tidak ada cara untuk mengobrol dengan pengguna lain"
-
-#~ msgid "User-to-user game interactions without chat functionality"
-#~ msgstr "Interaksi permainan antar pengguna tanpa fungsi obrolan"
-
-#~ msgid "Moderated chat functionality between users"
-#~ msgstr "Moderasi fungsi obrolan antar pengguna"
-
-#~ msgid "Uncontrolled chat functionality between users"
-#~ msgstr "Fungsi obrolan yang tidak terkontrol antara pengguna"
-
-#~ msgid "No way to talk with other users"
-#~ msgstr "Tidak ada cara untuk berbicara dengan pengguna lain"
-
-#~ msgid "Uncontrolled audio or video chat functionality between users"
-#~ msgstr ""
-#~ "Fungsi obrolan audio atau video yang tidak terkontrol antara pengguna"
-
-#~ msgid "No sharing of social network usernames or email addresses"
-#~ msgstr "Tidak berbagi alamat surel atau nama pengguna media sosial"
-
-#~ msgid "Sharing social network usernames or email addresses"
-#~ msgstr "Berbagi nama pengguna jejaring sosial atau alamat surel"
-
-#~ msgid "No sharing of user information with 3rd parties"
-#~ msgstr "Tidak berbagi informasi pengguna dengan pihak ke-3"
-
-#~ msgid "Checking for the latest application version"
-#~ msgstr "Memeriksa versi aplikasi terbaru"
-
-#~ msgid "Sharing diagnostic data that does not let others identify the user"
-#~ msgstr ""
-#~ "Berbagi data diagnostik yang tidak membiarkan orang lain mengidentifikasi "
-#~ "pengguna"
-
-#~ msgid "Sharing information that lets others identify the user"
-#~ msgstr ""
-#~ "Berbagi informasi yang memungkinkan orang lain mengidentifikasi pengguna"
-
-#~ msgid "No sharing of physical location to other users"
-#~ msgstr "Tidak berbagi lokasi fisik ke pengguna lain"
-
-#~ msgid "Sharing physical location to other users"
-#~ msgstr "Berbagi lokasi fisik dengan pengguna lain"
-
-#~ msgid "No references to homosexuality"
-#~ msgstr "Tidak ada referensi ke homoseksualitas"
-
-#~ msgid "Indirect references to homosexuality"
-#~ msgstr "Referensi tak langsung ke homoseksualitas"
-
-#~ msgid "Kissing between people of the same gender"
-#~ msgstr "Berciuman antara orang-orang dengan jenis kelamin yang sama"
-
-#~ msgid "Graphic sexual behavior between people of the same gender"
-#~ msgstr "Perilaku seksual grafis antara orang dengan jenis kelamin yang sama"
-
-#~ msgid "No references to prostitution"
-#~ msgstr "Tidak ada referensi untuk prostitusi"
-
-#~ msgid "Indirect references to prostitution"
-#~ msgstr "Referensi tidak langsung untuk prostitusi"
-
-#~ msgid "Direct references to prostitution"
-#~ msgstr "Referensi langsung ke prostitusi"
-
-#~ msgid "Graphic depictions of the act of prostitution"
-#~ msgstr "Penggambaran grafis dari aksi prostitusi"
-
-#~ msgid "No references to adultery"
-#~ msgstr "Tidak ada referensi untuk perzinaan"
-
-#~ msgid "Indirect references to adultery"
-#~ msgstr "Referensi tidak langsung untuk perzinaan"
-
-#~ msgid "Direct references to adultery"
-#~ msgstr "Referensi langsung ke perzinaan"
-
-#~ msgid "Graphic depictions of the act of adultery"
-#~ msgstr "Penggambaran grafis dari tindakan perzinaan"
-
-#~ msgid "No sexualized characters"
-#~ msgstr "Tidak ada karakter seksual"
-
-#~ msgid "Scantily clad human characters"
-#~ msgstr "Karakter manusia berpakaian minim"
-
-#~ msgid "Overtly sexualized human characters"
-#~ msgstr "Karakter manusia seksual secara menyeluruh"
-
-#~ msgid "No references to desecration"
-#~ msgstr "Tidak ada referensi untuk penodaan"
-
-#~ msgid "Depictions or references to historical desecration"
-#~ msgstr "Penggambaran atau referensi tentang penodaan sejarah"
-
-#~ msgid "Depictions of modern-day human desecration"
-#~ msgstr "Penggambaran tentang penodaan manusia zaman modern"
-
-#~ msgid "Graphic depictions of modern-day desecration"
-#~ msgstr "Penggambaran grafis tentang penodaan modern"
-
-#~ msgid "No visible dead human remains"
-#~ msgstr "Tidak ada sisa manusia mati yang terlihat"
-
-#~ msgid "Visible dead human remains"
-#~ msgstr "Sisa manusia mati yang terlihat"
-
-#~ msgid "Dead human remains that are exposed to the elements"
-#~ msgstr "Sisa manusia mati yang terpapar unsur"
-
-#~ msgid "Graphic depictions of desecration of human bodies"
-#~ msgstr "Penggambaran grafis penodaan tubuh manusia"
-
-#~ msgid "No references to slavery"
-#~ msgstr "Tidak ada referensi untuk perbudakan"
-
-#~ msgid "Depictions or references to historical slavery"
-#~ msgstr "Penggambaran atau referensi tentang perbudakan bersejarah"
-
-#~ msgid "Depictions of modern-day slavery"
-#~ msgstr "Penggambaran perbudakan modern"
-
-#~ msgid "Graphic depictions of modern-day slavery"
-#~ msgstr "Penggambaran grafis tentang perbudakan modern"

--- a/po/it.po
+++ b/po/it.po
@@ -1,15 +1,15 @@
 # Italian translations for malcontent package.
-# Copyright (C) 2020 Free Software Foundation, Inc.
+# Copyright (C) 2020, 2021 Free Software Foundation, Inc.
 # This file is distributed under the same license as the malcontent package.
-# Milo Casagrande <milo@milo.name>, 2020.
+# Milo Casagrande <milo@milo.name>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: malcontent\n"
 "Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
 "issues\n"
-"POT-Creation-Date: 2020-09-10 03:28+0000\n"
-"PO-Revision-Date: 2020-09-13 14:25+0200\n"
+"POT-Creation-Date: 2020-12-18 15:14+0000\n"
+"PO-Revision-Date: 2021-03-17 11:27+0100\n"
 "Last-Translator: Milo Casagrande <milo@milo.name>\n"
 "Language-Team: none\n"
 "Language: it\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:4
 msgid "Change your own app filter"
@@ -135,29 +135,29 @@ msgstr "Il filtro app per l'utente %u era in un formato non riconosciuto"
 msgid "OARS filter for user %u has an unrecognized kind ‘%s’"
 msgstr "Il filtro OARS per l'utente %u presenta un tipo «%s» non riconosciuto"
 
-#: libmalcontent/manager.c:283 libmalcontent/manager.c:412
+#: libmalcontent/manager.c:283 libmalcontent/manager.c:420
+#: libmalcontent/manager.c:803
 #, c-format
-msgid "Not allowed to query app filter data for user %u"
-msgstr "Non è consentito richiedere i dati dei filtri app per l'utente %u"
+msgid "Not allowed to query parental controls data for user %u"
+msgstr ""
+"Non è consentito richiedere i dati sui controlli parentali per l'utente %u"
 
 #: libmalcontent/manager.c:288
 #, c-format
 msgid "User %u does not exist"
 msgstr "L'utente %u non esiste"
 
-#: libmalcontent/manager.c:394
+#: libmalcontent/manager.c:296
+msgid "System accounts service not available"
+msgstr ""
+
+#: libmalcontent/manager.c:402
 msgid "App filtering is globally disabled"
 msgstr "I filtri sulle app sono disabilitati globalmente"
 
-#: libmalcontent/manager.c:777
+#: libmalcontent/manager.c:785
 msgid "Session limits are globally disabled"
 msgstr "I limiti sulla sessione sono disabilitati globalmente"
-
-#: libmalcontent/manager.c:795
-#, c-format
-msgid "Not allowed to query session limits data for user %u"
-msgstr ""
-"Non è consentito richiedere i dati dei limiti di sessione per l'utente %u"
 
 #: libmalcontent/session-limits.c:306
 #, c-format
@@ -239,17 +239,17 @@ msgid "No applications found to restrict."
 msgstr "Non è stata trovata alcuna applicazione da limitare."
 
 #. Translators: this is the full name for an unknown user account.
-#: libmalcontent-ui/user-controls.c:242 libmalcontent-ui/user-controls.c:253
+#: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
 msgstr "sconosciuto"
 
-#: libmalcontent-ui/user-controls.c:338 libmalcontent-ui/user-controls.c:425
-#: libmalcontent-ui/user-controls.c:711
+#: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
+#: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
 msgstr "Tutte le età"
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:514
+#: libmalcontent-ui/user-controls.c:477
 #, c-format
 msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
@@ -259,53 +259,42 @@ msgstr ""
 "possono comunque essere accessibili in altre applicazioni."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:519
+#: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
 msgstr "Impedisce all'utente %s di utilizzare applicazioni specifiche."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:524
+#: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
 msgstr "Impedisce all'utente %s di installare applicazioni."
 
-#. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:529
-#, c-format
-msgid "Applications installed by %s will not appear for other users."
-msgstr ""
-"Le applicazioni installate da %s non saranno visualizzate da altri utenti."
-
-#: libmalcontent-ui/user-controls.ui:17
+#: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
 msgstr "Limitazioni utilizzo applicazioni"
 
-#: libmalcontent-ui/user-controls.ui:68
+#: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
 msgstr "Limita browser _web"
 
-#: libmalcontent-ui/user-controls.ui:152
+#: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
 msgstr "_Limita applicazioni"
 
-#: libmalcontent-ui/user-controls.ui:231
+#: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
 msgstr "Limitazioni installazione software"
 
-#: libmalcontent-ui/user-controls.ui:281
+#: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
 msgstr "Limita _installazione applicazioni"
 
-#: libmalcontent-ui/user-controls.ui:366
-msgid "Restrict Application Installation for _Others"
-msgstr "Limita installazione applicazioni ad _altri"
-
-#: libmalcontent-ui/user-controls.ui:451
+#: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
 msgstr "Co_mpatibilità applicazioni"
 
-#: libmalcontent-ui/user-controls.ui:473
+#: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
@@ -313,43 +302,78 @@ msgstr ""
 "Limita l'esplorazione o l'installazione di applicazioni a solo quelle "
 "compatibili con certe fasce d'età."
 
+#. Translators: This documents the --user command line option to malcontent-control:
+#: malcontent-control/application.c:102
+msgid "User to select in the UI"
+msgstr "Utente da selezionare nell'interfaccia utente"
+
+#. Translators: This is a placeholder for a command line argument value:
+#: malcontent-control/application.c:104
+msgid "USERNAME"
+msgstr "NOMEUTENTE"
+
+#: malcontent-control/application.c:115
+msgid "— view and edit parental controls"
+msgstr "— Visualizza e modifica i controlli parentali"
+
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
-#: malcontent-control/application.c:105 malcontent-control/main.ui:12
+#: malcontent-control/application.c:122 malcontent-control/main.ui:12
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:9
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:3
 msgid "Parental Controls"
 msgstr "Controlli parentali"
 
-#: malcontent-control/application.c:270
+#: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
 msgstr "Copyright © 2019, 2020 Endless Mobile, Inc."
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
-#: malcontent-control/application.c:275
+#: malcontent-control/application.c:313
 msgid "translator-credits"
 msgstr "Milo Casagrande <milo@milo.name>, 2020"
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
-#: malcontent-control/application.c:281
+#: malcontent-control/application.c:319
 msgid "Malcontent Website"
 msgstr "Sito web di Malcontent"
 
-#: malcontent-control/application.c:299
+#: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
 msgstr "I contenuti dell'aiuto non possono essere visualizzati"
 
-#: malcontent-control/application.c:336
+#: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
 msgstr "Caricamento dei dati utente dal sistema non riuscito"
 
-#: malcontent-control/application.c:338
+#: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
 msgstr ""
 "Assicurarsi che il servizio AccountsService sia installato e abilitato."
+
+#. Translators: Replace the link to commonsensemedia.org with some
+#. * localised guidance for parents/carers on how to set restrictions on
+#. * their child/caree in a responsible way which is in keeping with the
+#. * best practice and culture of the region. If no suitable localised
+#. * guidance exists, and if the default commonsensemedia.org link is not
+#. * suitable, please file an issue against malcontent so we can discuss
+#. * further!
+#. * https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/new
+#.
+#: malcontent-control/application.c:407
+#, c-format
+msgid ""
+"It’s recommended that restrictions are set as part of an ongoing "
+"conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Read guidance</a> on what to consider."
+msgstr ""
+"Si consiglia di impostare le restrizioni come parte di una conversazione "
+"attiva con %s. Per maggiori informazioni su cosa considerare per le "
+"restrizioni, è possibile <a href='https://www.internetmatters.org/it/"
+"resources/online-safety-guide/'>consultare questa guida</a>."
 
 #: malcontent-control/carousel.ui:48
 msgid "Previous Page"
@@ -359,42 +383,42 @@ msgstr "Pagina precedente"
 msgid "Next Page"
 msgstr "Pagina successiva"
 
-#: malcontent-control/main.ui:93
+#: malcontent-control/main.ui:115
 msgid "Permission Required"
 msgstr "Richiesti permessi"
 
-#: malcontent-control/main.ui:107
+#: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
 "È richiesto avere i permessi necessari per visualizzare e modificare i "
 "controlli parentali dell'utente."
 
-#: malcontent-control/main.ui:148
-msgid "No Child Users Configured"
-msgstr "Nessun utente bambino configurato"
+#: malcontent-control/main.ui:184
+msgid "No Standard User Accounts"
+msgstr "Nessun account utente standard"
 
-#: malcontent-control/main.ui:162
+#: malcontent-control/main.ui:199
 msgid ""
-"No child users are currently set up on the system. Create one before setting "
-"up their parental controls."
+"Parental controls can only be applied to standard user\n"
+"accounts. These can be created in the user settings."
 msgstr ""
-"Nessun utente bambino è configurato nel sistema. Crearne uno prima di "
-"impostarne i controlli parentali."
+"I controlli parentali possono essere applicati solo agli account utenti\n"
+"standard. Questi possono essere creati nelle impostazioni utente."
 
-#: malcontent-control/main.ui:174
-msgid "Create _Child User"
-msgstr "Crea utente _bambino"
+#: malcontent-control/main.ui:212
+msgid "_User Settings"
+msgstr "Impostazioni _utente"
 
-#: malcontent-control/main.ui:202
+#: malcontent-control/main.ui:242
 msgid "Loading…"
 msgstr "Caricamento…"
 
-#: malcontent-control/main.ui:265
+#: malcontent-control/main.ui:305
 msgid "_Help"
 msgstr "A_iuto"
 
-#: malcontent-control/main.ui:269
+#: malcontent-control/main.ui:309
 msgid "_About Parental Controls"
 msgstr "I_nformazioni su Controlli parentali"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -9,8 +9,8 @@ msgstr ""
 "Project-Id-Version: malcontent\n"
 "Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
 "issues\n"
-"POT-Creation-Date: 2020-10-22 15:27+0000\n"
-"PO-Revision-Date: 2020-10-25 09:20+0100\n"
+"POT-Creation-Date: 2020-12-18 15:14+0000\n"
+"PO-Revision-Date: 2020-12-20 13:30+0100\n"
 "Last-Translator: Piotr Drąg <piotrdrag@gmail.com>\n"
 "Language-Team: Polish <community-poland@mozilla.org>\n"
 "Language: pl\n"
@@ -231,8 +231,8 @@ msgstr "Dla małych dzieci"
 #, c-format
 msgid "Restrict %s from using the following installed applications."
 msgstr ""
-"Ograniczanie użytkownikowi „%s” możliwości używania poniższych "
-"zainstalowanych programów."
+"Ograniczanie użytkownikowi %s możliwości używania poniższych zainstalowanych "
+"programów."
 
 #: libmalcontent-ui/restrict-applications-dialog.ui:6
 #: libmalcontent-ui/restrict-applications-dialog.ui:12
@@ -244,74 +244,62 @@ msgid "No applications found to restrict."
 msgstr "Nie odnaleziono żadnych programów do ograniczenia."
 
 #. Translators: this is the full name for an unknown user account.
-#: libmalcontent-ui/user-controls.c:242 libmalcontent-ui/user-controls.c:253
+#: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
 msgstr "nieznany"
 
-#: libmalcontent-ui/user-controls.c:338 libmalcontent-ui/user-controls.c:425
-#: libmalcontent-ui/user-controls.c:711
+#: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
+#: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
 msgstr "W każdym wieku"
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:514
+#: libmalcontent-ui/user-controls.c:477
 #, c-format
 msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
 "available in other applications."
 msgstr ""
-"Uniemożliwia użytkownikowi „%s” używanie przeglądarek internetowych. Pewne "
+"Uniemożliwia użytkownikowi %s używanie przeglądarek internetowych. Pewne "
 "treści internetowe mogą nadal być dostępne w innych programach."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:519
+#: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
-msgstr "Uniemożliwia użytkownikowi „%s” używanie podanych programów."
+msgstr "Uniemożliwia użytkownikowi %s używanie podanych programów."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:524
+#: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
-msgstr "Uniemożliwia użytkownikowi „%s” instalowanie programów."
+msgstr "Uniemożliwia użytkownikowi %s instalowanie programów."
 
-#. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:529
-#, c-format
-msgid "Applications installed by %s will not appear for other users."
-msgstr ""
-"Programy zainstalowane przez użytkownika „%s” nie będą widoczne dla "
-"pozostałych użytkowników."
-
-#: libmalcontent-ui/user-controls.ui:17
+#: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
 msgstr "Ograniczenia używania programów"
 
-#: libmalcontent-ui/user-controls.ui:68
+#: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
 msgstr "_Ograniczanie przeglądarek internetowych"
 
-#: libmalcontent-ui/user-controls.ui:152
+#: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
 msgstr "Ogr_aniczanie programów"
 
-#: libmalcontent-ui/user-controls.ui:231
+#: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
 msgstr "Ograniczenia instalacji oprogramowania"
 
-#: libmalcontent-ui/user-controls.ui:281
+#: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
 msgstr "Ogra_niczanie instalacji programów"
 
-#: libmalcontent-ui/user-controls.ui:366
-msgid "Restrict Application Installation for _Others"
-msgstr "Ograni_czanie instalacji programów dla innych"
-
-#: libmalcontent-ui/user-controls.ui:451
+#: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
 msgstr "O_dpowiedniość programów"
 
-#: libmalcontent-ui/user-controls.ui:473
+#: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
@@ -320,35 +308,35 @@ msgstr ""
 "danego wieku."
 
 #. Translators: This documents the --user command line option to malcontent-control:
-#: malcontent-control/application.c:101
+#: malcontent-control/application.c:102
 msgid "User to select in the UI"
 msgstr "Użytkownik do wybrania w interfejsie użytkownika"
 
 #. Translators: This is a placeholder for a command line argument value:
-#: malcontent-control/application.c:103
+#: malcontent-control/application.c:104
 msgid "USERNAME"
 msgstr "NAZWA-UŻYTKOWNIKA"
 
-#: malcontent-control/application.c:114
+#: malcontent-control/application.c:115
 msgid "— view and edit parental controls"
 msgstr "— wyświetlanie i modyfikowanie kontroli rodzicielskiej"
 
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
-#: malcontent-control/application.c:121 malcontent-control/main.ui:12
+#: malcontent-control/application.c:122 malcontent-control/main.ui:12
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:9
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:3
 msgid "Parental Controls"
 msgstr "Kontrola rodzicielska"
 
-#: malcontent-control/application.c:306
+#: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
 msgstr "Copyright © 2019, 2020 Endless Mobile, Inc."
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
-#: malcontent-control/application.c:311
+#: malcontent-control/application.c:313
 msgid "translator-credits"
 msgstr ""
 "Piotr Drąg <piotrdrag@gmail.com>, 2020\n"
@@ -356,22 +344,42 @@ msgstr ""
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
-#: malcontent-control/application.c:317
+#: malcontent-control/application.c:319
 msgid "Malcontent Website"
 msgstr "Witryna projektu Malcontent"
 
-#: malcontent-control/application.c:335
+#: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
 msgstr "Nie można wyświetlić treści pomocy"
 
-#: malcontent-control/application.c:372
+#: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
 msgstr "Wczytanie danych użytkownika z systemu się nie powiodło"
 
-#: malcontent-control/application.c:374
+#: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
 msgstr ""
 "Proszę się upewnić, że usługa AccountsService jest zainstalowana i włączona."
+
+#. Translators: Replace the link to commonsensemedia.org with some
+#. * localised guidance for parents/carers on how to set restrictions on
+#. * their child/caree in a responsible way which is in keeping with the
+#. * best practice and culture of the region. If no suitable localised
+#. * guidance exists, and if the default commonsensemedia.org link is not
+#. * suitable, please file an issue against malcontent so we can discuss
+#. * further!
+#. * https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/new
+#.
+#: malcontent-control/application.c:407
+#, c-format
+msgid ""
+"It’s recommended that restrictions are set as part of an ongoing "
+"conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Read guidance</a> on what to consider."
+msgstr ""
+"Zalecane jest ustawianie ograniczeń jako część rozmowy z użytkownikiem %s. "
+"Można przeczytać <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>porady</a> na ten temat."
 
 #: malcontent-control/carousel.ui:48
 msgid "Previous Page"
@@ -381,42 +389,42 @@ msgstr "Poprzednia strona"
 msgid "Next Page"
 msgstr "Następna strona"
 
-#: malcontent-control/main.ui:93
+#: malcontent-control/main.ui:115
 msgid "Permission Required"
 msgstr "Wymagane jest pozwolenie"
 
-#: malcontent-control/main.ui:107
+#: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
 "Wymagane jest uprawnienie, aby wyświetlić lub zmienić ustawienia kontroli "
 "rodzicielskiej użytkownika."
 
-#: malcontent-control/main.ui:148
-msgid "No Child Users Configured"
-msgstr "Nie skonfigurowano żadnych kont dzieci"
+#: malcontent-control/main.ui:184
+msgid "No Standard User Accounts"
+msgstr "Brak standardowych kont użytkowników"
 
-#: malcontent-control/main.ui:162
+#: malcontent-control/main.ui:199
 msgid ""
-"No child users are currently set up on the system. Create one before setting "
-"up their parental controls."
+"Parental controls can only be applied to standard user\n"
+"accounts. These can be created in the user settings."
 msgstr ""
-"Na komputerze obecnie nie skonfigurowano żadnego konta dziecka. Należy "
-"utworzyć takie konto, aby móc skonfigurować jego kontrolę rodzicielską."
+"Kontrola rodzicielska może być stosowana tylko na standardowych\n"
+"kontach użytkowników. Można je utworzyć w ustawieniach użytkowników."
 
-#: malcontent-control/main.ui:174
-msgid "Create _Child User"
-msgstr "_Utwórz konto dziecka"
+#: malcontent-control/main.ui:212
+msgid "_User Settings"
+msgstr "_Ustawienia użytkowników"
 
-#: malcontent-control/main.ui:202
+#: malcontent-control/main.ui:242
 msgid "Loading…"
 msgstr "Wczytywanie…"
 
-#: malcontent-control/main.ui:265
+#: malcontent-control/main.ui:305
 msgid "_Help"
 msgstr "Pomo_c"
 
-#: malcontent-control/main.ui:269
+#: malcontent-control/main.ui:309
 msgid "_About Parental Controls"
 msgstr "_O programie"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -9,8 +9,8 @@ msgstr ""
 "Project-Id-Version: malcontent\n"
 "Report-Msgid-Bugs-To: https://gitlab.freedesktop.org/pwithnall/malcontent/"
 "issues\n"
-"POT-Creation-Date: 2020-09-08 15:27+0000\n"
-"PO-Revision-Date: 2020-09-13 22:37+0200\n"
+"POT-Creation-Date: 2020-12-09 03:28+0000\n"
+"PO-Revision-Date: 2020-12-17 18:28+0100\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
 #: accounts-service/com.endlessm.ParentalControls.policy.in:4
 msgid "Change your own app filter"
@@ -127,28 +127,28 @@ msgstr "Programfilter för användare %u var i ett okänt format"
 msgid "OARS filter for user %u has an unrecognized kind ‘%s’"
 msgstr "OARS-filter för användare %u har en okänd typ ”%s”"
 
-#: libmalcontent/manager.c:283 libmalcontent/manager.c:412
+#: libmalcontent/manager.c:283 libmalcontent/manager.c:420
+#: libmalcontent/manager.c:803
 #, c-format
-msgid "Not allowed to query app filter data for user %u"
-msgstr "Ej tillåtet att efterfråga programfilterdata för användare %u"
+msgid "Not allowed to query parental controls data for user %u"
+msgstr "Ej tillåtet att efterfråga föräldrakontrollsdata för användare %u"
 
 #: libmalcontent/manager.c:288
 #, c-format
 msgid "User %u does not exist"
 msgstr "Användare %u finns inte"
 
-#: libmalcontent/manager.c:394
+#: libmalcontent/manager.c:296
+msgid "System accounts service not available"
+msgstr "Systemkontotjänst ej tillgänglig"
+
+#: libmalcontent/manager.c:402
 msgid "App filtering is globally disabled"
 msgstr "Programfiltrering är globalt inaktiverad"
 
-#: libmalcontent/manager.c:777
+#: libmalcontent/manager.c:785
 msgid "Session limits are globally disabled"
 msgstr "Sessionsgränser är globalt inaktiverade"
-
-#: libmalcontent/manager.c:795
-#, c-format
-msgid "Not allowed to query session limits data for user %u"
-msgstr "Ej tillåtet att efterfråga sessionsgränsdata för användare %u"
 
 #: libmalcontent/session-limits.c:306
 #, c-format
@@ -227,17 +227,17 @@ msgid "No applications found to restrict."
 msgstr "Inga program att begränsa hittades."
 
 #. Translators: this is the full name for an unknown user account.
-#: libmalcontent-ui/user-controls.c:242 libmalcontent-ui/user-controls.c:253
+#: libmalcontent-ui/user-controls.c:207 libmalcontent-ui/user-controls.c:218
 msgid "unknown"
 msgstr "okänd"
 
-#: libmalcontent-ui/user-controls.c:338 libmalcontent-ui/user-controls.c:425
-#: libmalcontent-ui/user-controls.c:711
+#: libmalcontent-ui/user-controls.c:312 libmalcontent-ui/user-controls.c:397
+#: libmalcontent-ui/user-controls.c:669
 msgid "All Ages"
 msgstr "Alla åldrar"
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:514
+#: libmalcontent-ui/user-controls.c:477
 #, c-format
 msgid ""
 "Prevents %s from running web browsers. Limited web content may still be "
@@ -247,53 +247,42 @@ msgstr ""
 "fortfarande finnas tillgängligt i andra program."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:519
+#: libmalcontent-ui/user-controls.c:482
 #, c-format
 msgid "Prevents specified applications from being used by %s."
 msgstr "Förhindrar angivna program från att användas av %s."
 
 #. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:524
+#: libmalcontent-ui/user-controls.c:487
 #, c-format
 msgid "Prevents %s from installing applications."
 msgstr "Förhindrar %s från att installera program."
 
-#. Translators: The placeholder is a user’s display name.
-#: libmalcontent-ui/user-controls.c:529
-#, c-format
-msgid "Applications installed by %s will not appear for other users."
-msgstr "Program installerade av %s kommer inte visas för andra användare."
-
-#: libmalcontent-ui/user-controls.ui:17
+#: libmalcontent-ui/user-controls.ui:16
 msgid "Application Usage Restrictions"
 msgstr "Begränsningar av programanvändning"
 
-#: libmalcontent-ui/user-controls.ui:68
+#: libmalcontent-ui/user-controls.ui:67
 msgid "Restrict _Web Browsers"
 msgstr "Begränsa _webbläsare"
 
-#: libmalcontent-ui/user-controls.ui:152
+#: libmalcontent-ui/user-controls.ui:151
 msgid "_Restrict Applications"
 msgstr "_Begränsa program"
 
-#: libmalcontent-ui/user-controls.ui:231
+#: libmalcontent-ui/user-controls.ui:230
 msgid "Software Installation Restrictions"
 msgstr "Begränsningar av programvaruinstallation"
 
-#: libmalcontent-ui/user-controls.ui:281
+#: libmalcontent-ui/user-controls.ui:280
 msgid "Restrict Application _Installation"
 msgstr "Begränsa _installation av program"
 
-# Systeminstallation ej tillåtet, användaren kan bara installera åt sig själv
-#: libmalcontent-ui/user-controls.ui:366
-msgid "Restrict Application Installation for _Others"
-msgstr "Begränsa installation av program åt _andra"
-
-#: libmalcontent-ui/user-controls.ui:451
+#: libmalcontent-ui/user-controls.ui:365
 msgid "Application _Suitability"
 msgstr "_Lämplighet för program"
 
-#: libmalcontent-ui/user-controls.ui:473
+#: libmalcontent-ui/user-controls.ui:387
 msgid ""
 "Restricts browsing or installation of applications to applications suitable "
 "for certain ages or above."
@@ -301,42 +290,77 @@ msgstr ""
 "Begränsar bläddring bland eller installation av program till program som är "
 "lämpliga för vissa åldrar och uppåt."
 
+#. Translators: This documents the --user command line option to malcontent-control:
+#: malcontent-control/application.c:102
+msgid "User to select in the UI"
+msgstr "Användare att välja i användargränssnittet"
+
+#. Translators: This is a placeholder for a command line argument value:
+#: malcontent-control/application.c:104
+msgid "USERNAME"
+msgstr "ANVÄNDARNAMN"
+
+#: malcontent-control/application.c:115
+msgid "— view and edit parental controls"
+msgstr "— visa och redigera föräldrakontroller"
+
 #. Translators: This is the title of the main window
 #. Translators: the name of the application as it appears in a software center
-#: malcontent-control/application.c:105 malcontent-control/main.ui:12
+#: malcontent-control/application.c:122 malcontent-control/main.ui:12
 #: malcontent-control/org.freedesktop.MalcontentControl.appdata.xml.in:9
 #: malcontent-control/org.freedesktop.MalcontentControl.desktop.in:3
 msgid "Parental Controls"
 msgstr "Föräldrakontroller"
 
-#: malcontent-control/application.c:270
+#: malcontent-control/application.c:308
 msgid "Copyright © 2019, 2020 Endless Mobile, Inc."
 msgstr "Copyright © 2019, 2020 Endless Mobile, Inc."
 
 #. Translators: this should be "translated" to the
 #. names of people who have translated Malcontent into
 #. this language, one per line.
-#: malcontent-control/application.c:275
+#: malcontent-control/application.c:313
 msgid "translator-credits"
 msgstr "Anders Jonsson <anders.jonsson@norsjovallen.se>"
 
 #. Translators: "Malcontent" is the brand name of this
 #. project, so should not be translated.
-#: malcontent-control/application.c:281
+#: malcontent-control/application.c:319
 msgid "Malcontent Website"
 msgstr "Webbplats för Malcontent"
 
-#: malcontent-control/application.c:299
+#: malcontent-control/application.c:337
 msgid "The help contents could not be displayed"
 msgstr "Hjälpinnehållet kunde inte visas"
 
-#: malcontent-control/application.c:336
+#: malcontent-control/application.c:374
 msgid "Failed to load user data from the system"
 msgstr "Misslyckades med att läsa in användardata från systemet"
 
-#: malcontent-control/application.c:338
+#: malcontent-control/application.c:376
 msgid "Please make sure that the AccountsService is installed and enabled."
 msgstr "Försäkra dig om att AccountsService är installerat och aktiverat."
+
+#. Translators: Replace the link to commonsensemedia.org with some
+#. * localised guidance for parents/carers on how to set restrictions on
+#. * their child/caree in a responsible way which is in keeping with the
+#. * best practice and culture of the region. If no suitable localised
+#. * guidance exists, and if the default commonsensemedia.org link is not
+#. * suitable, please file an issue against malcontent so we can discuss
+#. * further!
+#. * https://gitlab.freedesktop.org/pwithnall/malcontent/-/issues/new
+#.
+#: malcontent-control/application.c:407
+#, c-format
+msgid ""
+"It’s recommended that restrictions are set as part of an ongoing "
+"conversation with %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Read guidance</a> on what to consider."
+msgstr ""
+"Det rekommenderas att begränsningar ställs in som en del av en pågående "
+"diskussion med %s. <a href='https://www.commonsensemedia.org/privacy-and-"
+"internet-safety'>Du kan läsa denna guide</a> (på engelska) om vad som finns "
+"att ta i beaktande."
 
 #: malcontent-control/carousel.ui:48
 msgid "Previous Page"
@@ -346,42 +370,43 @@ msgstr "Föregående sida"
 msgid "Next Page"
 msgstr "Nästa sida"
 
-#: malcontent-control/main.ui:93
+#: malcontent-control/main.ui:115
 msgid "Permission Required"
 msgstr "Behörighet krävs"
 
-#: malcontent-control/main.ui:107
+#: malcontent-control/main.ui:129
 msgid ""
 "Permission is required to view and change user parental controls settings."
 msgstr ""
 "Behörighet krävs för att visa och ändra inställningar för föräldrakontroll "
 "för användare."
 
-#: malcontent-control/main.ui:148
-msgid "No Child Users Configured"
-msgstr "Inga barnanvändare konfigurerade"
+#: malcontent-control/main.ui:182
+msgid "No Standard User Accounts"
+msgstr "Inga standardanvändarkonton"
 
-#: malcontent-control/main.ui:162
+#: malcontent-control/main.ui:197
 msgid ""
-"No child users are currently set up on the system. Create one before setting "
-"up their parental controls."
+"Parental controls can only be applied to standard user\n"
+"accounts. These can be created in the user settings."
 msgstr ""
-"Inga barnanvändare har konfigurerats på systemet. Skapa en innan du "
-"konfigurerar deras föräldrakontroller."
+"Föräldrakontroller kan endast tillämpas för\n"
+"standardanvändarkonton. Dessa kan skapas i\n"
+"användarinställningarna."
 
-#: malcontent-control/main.ui:174
-msgid "Create _Child User"
-msgstr "Skapa _barnanvändare"
+#: malcontent-control/main.ui:210
+msgid "_User Settings"
+msgstr "_Användarinställningar"
 
-#: malcontent-control/main.ui:202
+#: malcontent-control/main.ui:238
 msgid "Loading…"
 msgstr "Läser in…"
 
-#: malcontent-control/main.ui:265
+#: malcontent-control/main.ui:301
 msgid "_Help"
 msgstr "_Hjälp"
 
-#: malcontent-control/main.ui:269
+#: malcontent-control/main.ui:305
 msgid "_About Parental Controls"
 msgstr "_Om Föräldrakontroller"
 
@@ -453,3 +478,26 @@ msgstr "Användaren ”%s” har ingen återstående tid"
 #, c-format
 msgid "Error setting time limit on login session: %s"
 msgstr "Fel vid inställning av tidsgräns på inloggningssession: %s"
+
+#~ msgid "Not allowed to query session limits data for user %u"
+#~ msgstr "Ej tillåtet att efterfråga sessionsgränsdata för användare %u"
+
+#~ msgid "Applications installed by %s will not appear for other users."
+#~ msgstr "Program installerade av %s kommer inte visas för andra användare."
+
+# Systeminstallation ej tillåtet, användaren kan bara installera åt sig själv
+#~ msgid "Restrict Application Installation for _Others"
+#~ msgstr "Begränsa installation av program åt _andra"
+
+#~ msgid "No Child Users Configured"
+#~ msgstr "Inga barnanvändare konfigurerade"
+
+#~ msgid ""
+#~ "No child users are currently set up on the system. Create one before "
+#~ "setting up their parental controls."
+#~ msgstr ""
+#~ "Inga barnanvändare har konfigurerats på systemet. Skapa en innan du "
+#~ "konfigurerar deras föräldrakontroller."
+
+#~ msgid "Create _Child User"
+#~ msgstr "Skapa _barnanvändare"


### PR DESCRIPTION
This rebases on `upstream/main` as of today, which is 0.10.2 plus a few patches. In particular, this includes https://gitlab.freedesktop.org/pwithnall/malcontent/-/merge_requests/126, which is the fix for focus handling in https://phabricator.endlessm.com/T32618.

This drops one downstream patch which has been upstreamed, and adds a revert of an upstream patch which hid `malcontent-client` from gnome-shell’s app grid. I don’t think we want that in Endless OS at the moment. The revert maintains the status quo in EOS.

https://phabricator.endlessm.com/T32618